### PR TITLE
Fix file manipulations for non-element files

### DIFF
--- a/assets/components/seaccelerator/js/mgr/widgets/files.grid.js
+++ b/assets/components/seaccelerator/js/mgr/widgets/files.grid.js
@@ -93,12 +93,12 @@ Seaccelerator.grid.Files = function(config) {
 		,listeners: {
 			'change': {fn: this.filterByName, scope: this}
 			,'render': {fn: function(cmp) {
-					new Ext.KeyMap(cmp.getEl(), {
-						key: Ext.EventObject.ENTER
-						,fn: this.blur
-						,scope: cmp
-					});
-				},scope:this}
+				new Ext.KeyMap(cmp.getEl(), {
+					key: Ext.EventObject.ENTER
+					,fn: this.blur
+					,scope: cmp
+				});
+			},scope:this}
 		}
 	}/*,{
 		xtype: 'button'
@@ -200,11 +200,11 @@ Seaccelerator.grid.Files = function(config) {
 		,remoteSort: true
 		,listeners: {
 			'afterAutoSave': {fn:function() {
-					this.refresh();
-				},scope:this}
+				this.refresh();
+			},scope:this}
 			,'afterEdit': {fn:function(e) {
-					e.record.data.type = config.type;
-				}}
+				e.record.data.type = config.type;
+			}}
 		}
 	});
 
@@ -334,8 +334,8 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 			}
 			,listeners: {
 				'success': {fn:function(){
-						this.refresh();
-					},scope:this}
+					this.refresh();
+				},scope:this}
 			}
 		});
 	}
@@ -362,15 +362,15 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 			}
 			,listeners: {
 				'success': {fn:function(r) {
-						MODx.util.Progress.reset();
-						Ext.Msg.hide();
-						this.refresh();
-					},scope:this}
+					MODx.util.Progress.reset();
+					Ext.Msg.hide();
+					this.refresh();
+				},scope:this}
 				,'failure': {fn:function(r) {
-						MODx.util.Progress.reset();
-						Ext.Msg.hide();
-						return false;
-					},scope:this}
+					MODx.util.Progress.reset();
+					Ext.Msg.hide();
+					return false;
+				},scope:this}
 			}
 		});
 	}
@@ -396,8 +396,8 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 			,action: 'mgr/files/update'
 			,listeners: {
 				'success': {fn:function(){
-						this.refresh();
-					},scope:this}
+					this.refresh();
+				},scope:this}
 			}
 		});
 
@@ -430,8 +430,8 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 			}
 			,listeners: {
 				'success': {fn:function(){
-						this.refresh();
-					},scope:this}
+					this.refresh();
+				},scope:this}
 			}
 		});
 	}

--- a/assets/components/seaccelerator/js/mgr/widgets/files.grid.js
+++ b/assets/components/seaccelerator/js/mgr/widgets/files.grid.js
@@ -93,12 +93,12 @@ Seaccelerator.grid.Files = function(config) {
 		,listeners: {
 			'change': {fn: this.filterByName, scope: this}
 			,'render': {fn: function(cmp) {
-				new Ext.KeyMap(cmp.getEl(), {
-					key: Ext.EventObject.ENTER
-					,fn: this.blur
-					,scope: cmp
-				});
-			},scope:this}
+					new Ext.KeyMap(cmp.getEl(), {
+						key: Ext.EventObject.ENTER
+						,fn: this.blur
+						,scope: cmp
+					});
+				},scope:this}
 		}
 	}/*,{
 		xtype: 'button'
@@ -200,11 +200,11 @@ Seaccelerator.grid.Files = function(config) {
 		,remoteSort: true
 		,listeners: {
 			'afterAutoSave': {fn:function() {
-				this.refresh();
-			},scope:this}
+					this.refresh();
+				},scope:this}
 			,'afterEdit': {fn:function(e) {
-				e.record.data.type = config.type;
-			}}
+					e.record.data.type = config.type;
+				}}
 		}
 	});
 
@@ -334,8 +334,8 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 			}
 			,listeners: {
 				'success': {fn:function(){
-					this.refresh();
-				},scope:this}
+						this.refresh();
+					},scope:this}
 			}
 		});
 	}
@@ -362,15 +362,15 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 			}
 			,listeners: {
 				'success': {fn:function(r) {
-					MODx.util.Progress.reset();
-					Ext.Msg.hide();
-					this.refresh();
-				},scope:this}
+						MODx.util.Progress.reset();
+						Ext.Msg.hide();
+						this.refresh();
+					},scope:this}
 				,'failure': {fn:function(r) {
-					MODx.util.Progress.reset();
-					Ext.Msg.hide();
-					return false;
-				},scope:this}
+						MODx.util.Progress.reset();
+						Ext.Msg.hide();
+						return false;
+					},scope:this}
 			}
 		});
 	}
@@ -385,7 +385,7 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 
 		rec.name = rec.filename;
 		rec.source = 0;
-		rec.file = rec.path;
+		rec.file = rec.path + rec.filename;
 		rec.clearCache = 1;
 
 		var que = MODx.load({
@@ -396,8 +396,8 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 			,action: 'mgr/files/update'
 			,listeners: {
 				'success': {fn:function(){
-					this.refresh();
-				},scope:this}
+						this.refresh();
+					},scope:this}
 			}
 		});
 
@@ -410,8 +410,8 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 		var path, filename, mediasource;
 		if (typeof record.data !== "undefined") {
 			path = record.data.path;
-			filename = record.data.path;
-			mediasource = record.data.path;
+			filename = record.data.filename;
+			mediasource = record.data.mediasource;
 		} else {
 			path = this.menu.record.path;
 			filename = this.menu.record.filename;
@@ -430,8 +430,8 @@ Ext.extend(Seaccelerator.grid.Files,MODx.grid.Grid,{
 			}
 			,listeners: {
 				'success': {fn:function(){
-					this.refresh();
-				},scope:this}
+						this.refresh();
+					},scope:this}
 			}
 		});
 	}

--- a/core/components/seaccelerator/processors/mgr/files/update.php
+++ b/core/components/seaccelerator/processors/mgr/files/update.php
@@ -10,16 +10,19 @@ if (!isset($modx->seaccelerator) || !is_object($modx->seaccelerator)) {
 	if (!($seaccelerator instanceof Seaccelerator)) return '---';
 }
 
-$fileName 	 = $modx->getOption('filename', $_REQUEST);
+$file 	 = $modx->getOption('file', $_REQUEST);
 $mediaSource = $modx->getOption('mediasource', $_REQUEST);
-$path 			 = $modx->getOption('path', $_REQUEST);
 $content 		 = $modx->getOption('content', $_REQUEST);
 
+$result = false;
+if($file){
+	$file = $modx->seaccelerator->makeStaticElementFilePath('', $file, $mediaSource, true);
+	
+	$result = file_put_contents ($file, $content);
+}
 
-if($fileName && $path){
-	$file = $seaccelerator->makeStaticElementFilePath($fileName, $mediaSource, $path, true);
-
-	file_put_contents ($file, $content);
-
-	return $modx->error->success('',$item);
+if (false !== $result) {
+	return $modx->error->success("");
+} else {
+	return $modx->error->failure("");
 }

--- a/core/components/seaccelerator/processors/mgr/files/update.php
+++ b/core/components/seaccelerator/processors/mgr/files/update.php
@@ -17,7 +17,7 @@ $content 		 = $modx->getOption('content', $_REQUEST);
 
 
 if($fileName && $path){
-	$file = $seaccelerator->makeStaticElementFilePath($fileName, $mediaSource, $path, true);
+	$file = $seaccelerator->makeStaticElementFilePath($fileName, $path, $mediaSource, true);
 
 	file_put_contents ($file, $content);
 


### PR DESCRIPTION
- Multiple issues prevented edits from being saved for files listed on the Files tab in Manager.
- Also files were unable to be deleted in some cases because of wrong way accessing file parameters like record.data.filename and record.data.mediasource