### PR TITLE
Fixes for file path handling

### DIFF
--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -356,7 +356,7 @@ class Seaccelerator {
 		$elementsPath = $this->getBaseFilesystemPath( $mediaSourceId );
 		
 		if($makeFullPath !== true) {
-			$elementsPath = str_replace( MODX_BASE_PATH, '', $elementsPath);
+			$elementsPath = str_replace( MODX_BASE_PATH, '/', $elementsPath);
 		}
 		
 		$staticElementFilePath = $elementsPath . $filePath . $fileName;

--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -186,15 +186,26 @@ class Seaccelerator {
 
 		return $mediaSourceId;
 	}
-
-
+	
+	/**
+	 * Gets the default elements directory from the System Settings.
+	 *
+	 * The path is relative to the base path for the static elements. It has no
+	 * starting slash, but has ending slash, e.g.: "elements/"
+	 *
+	 * @return string
+	 */
+	public function getElementsDirectory() {
+		return $this->modx->getOption('seaccelerator.elements_directory', null, 'elements/');
+	}
+	
 	/**
 	 * @return string
 	 */
 	public function getElementsLocationFilesystemPath() {
 
 		$mediaSourceId = $this->getElementsMediaSource();
-		$elementsDirectory = $this->modx->getOption("seaccelerator.elements_directory", null, "elements");
+		$elementsDirectory = $this->getElementsDirectory();
 		if($mediaSourceId == 1) {
 			$elementsPath = MODX_BASE_PATH . $this->getMediaSourcePath($elementsDirectory, $mediaSourceId);
 		} else if ($mediaSourceId > 1) {
@@ -310,8 +321,9 @@ class Seaccelerator {
 		} else {
 			$mediaSourceId = $mediaSource;
 		}
-
-    $elementsPath = $this->modx->getOption("seaccelerator.elements_directory", null, "elements/");
+		
+		$elementsPath = $this->getElementsDirectory();
+		
 		if($makeFullPath == true) {
       $elementsPath = $this->getMediaSourcePath($filePath, $mediaSourceId);
 			$staticElementFilePath = MODX_BASE_PATH.$elementsPath.$fileName;

--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -22,14 +22,14 @@
  * @package seaccelerator
  */
 class Seaccelerator {
-
+	
 	public $modx = null;
 	public $map = array();
 	public $config = array();
-  public $elementFileRules;
-  public $defaultMediaSource;
-
-
+	public $elementFileRules;
+	public $defaultMediaSource;
+	
+	
 	/**
 	 * Constructs the Seaccelerator object
 	 *
@@ -38,33 +38,33 @@ class Seaccelerator {
 	 */
 	function __construct(modX &$modx,array $config = array()) {
 		$this->modx =& $modx;
-
+		
 		$basePath = $this->modx->getOption("seaccelerator.core_path", null, $this->modx->getOption("core_path")."components/seaccelerator/");
 		$assetsUrl = $this->modx->getOption("seaccelerator.assets_url", null, $this->modx->getOption("assets_url")."components/seaccelerator/");
-
+		
 		$this->config = array_merge(array(
-			"basePath" => $basePath,
-			"corePath" => $basePath,
-			"modelPath" => $basePath."model/",
-			"processorsPath" => $basePath."processors/",
-			"templatesPath" => $basePath."templates/",
-			"chunksPath" => $basePath."elements/chunks/",
-			"jsUrl" => $assetsUrl."js/",
-			"cssUrl" => $assetsUrl."css/",
-			"assetsUrl" => $assetsUrl,
-			"connectorUrl" => $assetsUrl."connector.php",
-		),$config);
-
-    $this->elementFileRules = explode(",", $this->modx->getOption("seaccelerator.element_type_rules", null, "modChunk:chunks,modSnippet:snippets,modTemplate:templates,modPlugin:plugins"));
-    $this->defaultMediaSource = $this->modx->getOption("seaccelerator.mediasource", null, 1);
-
+			                            "basePath" => $basePath,
+			                            "corePath" => $basePath,
+			                            "modelPath" => $basePath."model/",
+			                            "processorsPath" => $basePath."processors/",
+			                            "templatesPath" => $basePath."templates/",
+			                            "chunksPath" => $basePath."elements/chunks/",
+			                            "jsUrl" => $assetsUrl."js/",
+			                            "cssUrl" => $assetsUrl."css/",
+			                            "assetsUrl" => $assetsUrl,
+			                            "connectorUrl" => $assetsUrl."connector.php",
+		                            ),$config);
+		
+		$this->elementFileRules = explode(",", $this->modx->getOption("seaccelerator.element_type_rules", null, "modChunk:chunks,modSnippet:snippets,modTemplate:templates,modPlugin:plugins"));
+		$this->defaultMediaSource = $this->modx->getOption("seaccelerator.mediasource", null, 1);
+		
 		$this->modx->addPackage("seaccelerator",$this->config["modelPath"]);
-
-    if ($this->modx->lexicon) {
-      $this->modx->lexicon->load ('seaccelerator:default');
-    }
+		
+		if ($this->modx->lexicon) {
+			$this->modx->lexicon->load ('seaccelerator:default');
+		}
 	}
-
+	
 	/**
 	 * Initializes the class into the proper context
 	 *
@@ -75,7 +75,7 @@ class Seaccelerator {
 		switch($ctx) {
 			case "mgr":
 				$this->modx->lexicon->load("seaccelerator:default");
-
+				
 				if(!$this->modx->loadClass("seacceleratorControllerRequest",$this->config["modelPath"]."seaccelerator/request/",true,true)) {
 					return "Could not load controller request handler.";
 				}
@@ -83,28 +83,28 @@ class Seaccelerator {
 				return $this->request->handleRequest();
 				break;
 		}
-
+		
 		return true;
 	}
-
-
+	
+	
 	/**
 	 * @return mixed
 	 */
 	public function getElementsMediaSource() {
-
+		
 		$mediaSourceId = $this->modx->getOption("seaccelerator.mediasource", null, 1);
-
+		
 		return $mediaSourceId;
 	}
-
-
+	
+	
 	/**
 	 * @param $mediaSourceId
 	 * @return bool
 	 */
 	public function getMediaSourceName($mediaSourceId) {
-
+		
 		$mediaSource = $this->modx->getObject("sources.modMediaSource", $mediaSourceId);
 		if(!empty($mediaSource) && is_object($mediaSource)) {
 			return $mediaSource->get("name");
@@ -112,14 +112,14 @@ class Seaccelerator {
 			return false;
 		}
 	}
-
-
+	
+	
 	/**
 	 * @param $results
 	 * @return mixed
 	 */
 	public function getMediaSourceNameFromArray ($results) {
-
+		
 		foreach ($results as $result) {
 			$source = $result->get("source");
 			$mediaSource = $this->modx->getObject('sources.modMediaSource', $source);
@@ -130,60 +130,62 @@ class Seaccelerator {
 			}
 			$result->set("mediasource", $mediaSourceName);
 		}
-
+		
 		return $results;
 	}
-
-
-  /**
-   * @return string
-   */
-  public function getMediaSources() {
-
-    $mediaSources = $this->modx->getObject('sources.modMediaSource');
-    foreach ($mediaSources as $source) {
-      $sources[] = array(
-          "id" => $source->get("id"),
-          "name" => $source->get("name")
-      );
-    }
-
-    return $this->modx->toJSON($sources);
-  }
-
-
+	
+	
 	/**
+	 * @return string
+	 */
+	public function getMediaSources() {
+		
+		$mediaSources = $this->modx->getObject('sources.modMediaSource');
+		foreach ($mediaSources as $source) {
+			$sources[] = array(
+				"id" => $source->get("id"),
+				"name" => $source->get("name")
+			);
+		}
+		
+		return $this->modx->toJSON($sources);
+	}
+	
+	
+	/**
+	 * Prepends the elementsPath with the path to a given MediaSource
+	 *
 	 * @param $elementsPath
 	 * @param $mediaSourceId
 	 * @return mixed
 	 */
 	public function getMediaSourcePath($elementsPath, $mediaSourceId) {
-
+		
 		$mediaSource = $this->modx->getObject("sources.modMediaSource", array('id' => $mediaSourceId));
 		if(!empty($mediaSource) && is_object($mediaSource)) {
 			$elementsPath = $mediaSource->prepareOutputUrl($elementsPath);
 		}
-
+		
 		return $elementsPath;
 	}
-
-
+	
+	
 	/**
 	 * @param $mediaSourceName
 	 * @return int
 	 */
 	public function getMediaSourceId($mediaSourceName) {
-
-    $c = $this->modx->newQuery('sources.modMediaSource');
-    $c->where(array('name' => $mediaSourceName));
-    $mediaSources = $this->modx->getCollectionGraph("sources.modMediaSource", $c);
-
+		
+		$c = $this->modx->newQuery('sources.modMediaSource');
+		$c->where(array('name' => $mediaSourceName));
+		$mediaSources = $this->modx->getCollectionGraph("sources.modMediaSource", $c);
+		
 		if(is_object($mediaSources)) {
-      $mediaSourceId = $mediaSources->get("id");
+			$mediaSourceId = $mediaSources->get("id");
 		} else {
 			$mediaSourceId = 1;
 		}
-
+		
 		return $mediaSourceId;
 	}
 	
@@ -202,12 +204,20 @@ class Seaccelerator {
 	/**
 	 * Gets the full filesystem path to the Elements root folder.
 	 *
+	 * @param null|integer $mediaSourceId Optional.
+	 *                                    If provided, the it defines which MediaSource should be considered.
+	 *                                    If not provided, the MediaSource defined by seaccelerator.mediasource Setting is used.
+	 *                                    If that setting is not a valid MediaSource ID, MODX_ASSETS_PATH is returned.
 	 * @return string
 	 */
-	public function getElementsLocationFilesystemPath() {
+	public function getElementsLocationFilesystemPath( $mediaSourceId = null ) {
+		
+		if ( ! isset($mediaSourceId) ) {
+			$mediaSourceId = $this->getElementsMediaSource();
+		}
 		$elementsDirectory = $this->getElementsDirectory();
 		
-		return $this->getBaseFilesystemPath() . $elementsDirectory;
+		return $this->getBaseFilesystemPath( $mediaSourceId) . $elementsDirectory;
 	}
 	
 	/**
@@ -216,55 +226,62 @@ class Seaccelerator {
 	 * If there is a MediaSource defined, it is the root path of the MediaSource. Otherwise it uses the MODX_ASSETS_PATH
 	 * as a default.
 	 *
+	 * @param null|integer $mediaSourceId Optional.
+	 *                                    If provided, the it defines which MediaSource should be considered.
+	 *                                    If not provided, the MediaSource defined by seaccelerator.mediasource Setting is used.
+	 *                                    If that setting is not a valid MediaSource ID, MODX_ASSETS_PATH is returned.
+	 *
 	 * @return string
 	 */
-	public function getBaseFilesystemPath() {
+	public function getBaseFilesystemPath( $mediaSourceId = null ) {
 		
-		$mediaSourceId = $this->getElementsMediaSource();
+		if ( ! isset($mediaSourceId) ) {
+			$mediaSourceId = $this->getElementsMediaSource();
+		}
 		if($mediaSourceId >= 1) {
 			$elementsPath = MODX_BASE_PATH . $this->getMediaSourcePath('', $mediaSourceId);
 		} else {
 			$elementsPath = MODX_ASSETS_PATH;
 		}
-
+		
 		return $elementsPath;
 	}
-
-
+	
+	
 	/**
 	 * @return array
 	 */
 	public function getNewFiles() {
-
+		
 		$actionCreateElement = json_decode('{"className":"check-square-o js_actionLink js_createElement","text":"'. $this->modx->lexicon('seaccelerator.files.actions.create') .'"}');
 		$actionEditFile = json_decode('{"className":"edit js_actionLink js_editFile","text":"' .$this->modx->lexicon('seaccelerator.files.actions.edit_file') .'"}');
 		$actionDeleteFile = json_decode('{"className":"trash js_actionLink js_deleteFile","text":"' .$this->modx->lexicon('seaccelerator.files.actions.delete_file') .'"}');
-
+		
 		$actions = array($actionCreateElement, $actionEditFile, $actionDeleteFile);
-
+		
 		$newFiles = array();
 		$elementsPath = $this->getElementsLocationFilesystemPath();
 		$filesystem = $this->scanElementsDirectory($elementsPath);
-
+		
 		foreach($filesystem as $file) {
 			$filePathArray = $this->getFilePathAsArray($file);
 			$fileName = array_shift ($filePathArray);
 			$elementModClass = $this->getElementClass($filePathArray);
-
+			
 			if(!$this->_isElementStatic($fileName, $elementModClass)) {
 				$mediaSourceId = $this->getElementsMediaSource();
 				$mediaSourceName = $this->getMediaSourceName($mediaSourceId);
 				$category = $this->getElementCategoryFromFilesystem($filePathArray);
 				$type = $this->_convertModElementClassToType($elementModClass);
-
+				
 				if($mediaSourceId > 0) {
-					$filePathString = $this->convertFilePathToString($filePathArray);
+					$filePathString = $this->getElementsDirectory() . $this->convertFilePathToString($filePathArray);
 				} else {
 					$filePathString = $elementsPath.$this->convertFilePathToString($filePathArray);
 				}
-
+				
 				$newFiles[] = array(
-          "file" => $file,
+					"file" => $file,
 					"filename" => $fileName,
 					"category" => $category,
 					"type" => $type,
@@ -276,39 +293,40 @@ class Seaccelerator {
 				);
 			}
 		}
-
+		
 		return $newFiles;
 	}
-
-
+	
+	
 	/**
 	 * @param $filePathArray
 	 * @return string
 	 */
 	public function convertFilePathToString($filePathArray) {
-
-    $filePathString = implode("/", array_reverse(array_filter($filePathArray)));
+		
+		$filePathString = implode("/", array_reverse(array_filter($filePathArray)));
 		if (substr($filePathString, -1, 1) != "/") {
 			$filePathString = $filePathString."/";
 		}
-
+		
 		return $filePathString;
 	}
-
-
+	
+	
 	/**
 	 * @param $fileNameString
 	 * @return array
 	 */
 	public function getFilePathAsArray($fileNameString) {
-
+		
 		$elementsPath = $this->getElementsLocationFilesystemPath();
 		$filePath = array_reverse(explode("/", str_replace($elementsPath, "", $fileNameString)));
-
+		
 		return $filePath;
 	}
-
-
+	
+	
+	// The static element file_path attribute is relative to the Media Source folder path, and contains no starting slash
 	/**
 	 * @param $fileName
 	 * @param $file
@@ -317,68 +335,63 @@ class Seaccelerator {
 	 * @return string
 	 */
 	public function makeStaticElementFilePath($fileName, $file, $mediaSource, $makeFullPath) {
-
+		
 		if ($fileName == '') {
-      //$filePathArray = $this->getFilePathAsArray($file);
-      $filePathArray = $this->getFilePathAsArray($file);
-      $fileName = array_shift($filePathArray);
-      $filePath = $this->convertFilePathToString($filePathArray);
+			//$filePathArray = $this->getFilePathAsArray($file);
+			$filePathArray = $this->getFilePathAsArray($file);
+			$fileName = array_shift($filePathArray);
+			$filePath = $this->convertFilePathToString($filePathArray);
 		} else {
 			$filePath = $file;
 		}
-
+		
 		if (!is_numeric($mediaSource)) {
-      $mediaSourceId = $this->getMediaSourceId($mediaSource);
-    } else if ($mediaSource == 0) {
-      $mediaSourceId = $this->defaultMediaSource;
+			$mediaSourceId = $this->getMediaSourceId($mediaSource);
+		} else if ($mediaSource == 0) {
+			$mediaSourceId = $this->defaultMediaSource;
 		} else {
 			$mediaSourceId = $mediaSource;
 		}
 		
-		$elementsPath = $this->getElementsDirectory();
+		$elementsPath = $this->getBaseFilesystemPath( $mediaSourceId );
 		
-		if($makeFullPath == true) {
-      $elementsPath = $this->getMediaSourcePath($filePath, $mediaSourceId);
-			$staticElementFilePath = MODX_BASE_PATH.$elementsPath.$fileName;
-
-		} else if($mediaSourceId > 0) {
-			$staticElementFilePath = $filePath.$fileName;
-
-		} else {
-			$staticElementFilePath = MODX_ASSETS_PATH.$elementsPath.$filePath.$fileName;
+		if($makeFullPath !== true) {
+			$elementsPath = str_replace( MODX_BASE_PATH, '', $elementsPath);
 		}
-
-    $staticElementFilePath = str_replace("//", "/", $staticElementFilePath);
+		
+		$staticElementFilePath = $elementsPath . $filePath . $fileName;
+		
+		$staticElementFilePath = str_replace("//", "/", $staticElementFilePath);
 		return $staticElementFilePath;
 	}
-
-
+	
+	
 	/**
 	 * @param $fileName
 	 * @param $filePath
 	 * @return string
 	 */
 	public function makeFilesystemPath($fileName, $filePath) {
-
+		
 		$file = MODX_BASE_PATH.$filePath."/".$fileName;
-
+		
 		return $file;
 	}
-
-
-  public function saveStaticElement($elementObject) {
-
-  }
-
-
-  /**
-   * @param $filePathArray
-   * @return int|mixed
-   */
+	
+	
+	public function saveStaticElement($elementObject) {
+	
+	}
+	
+	
+	/**
+	 * @param $filePathArray
+	 * @return int|mixed
+	 */
 	public function getElementCategoryFromFilesystem($filePathArray) {
-
-    $filePathArray = array_merge(array_filter($filePathArray));
-
+		
+		$filePathArray = array_merge(array_filter($filePathArray));
+		
 		$useCategories = $this->modx->getOption("seaccelerator.use_categories", null, true);
 		if($useCategories) {
 			$fullCategory = array_reverse($filePathArray);
@@ -393,58 +406,58 @@ class Seaccelerator {
 		} else {
 			$category = 0;
 		}
-
+		
 		return $category;
 	}
-
-
-  /**
-   * @param $filePathArray
-   * @return mixed
-   */
-  public function getElementCategoryPathFromFilesystem($filePathArray) {
-
-    return array_pop($filePathArray);
-  }
-
-
-  /**
-   * @param $categoryId
-   * @return string
-   */
-  public function getCategoryName ($categoryId) {
-
-    $categoryName = "";
-    if ($categoryId > 0) {
-      $categoryObj = $this->modx->getObject('modCategory', $categoryId);
-      if (is_object($categoryObj)){
-        $categoryName = $categoryObj->get('category');
-      }
-    }
-
-    return $categoryName;
-  }
-
-
+	
+	
+	/**
+	 * @param $filePathArray
+	 * @return mixed
+	 */
+	public function getElementCategoryPathFromFilesystem($filePathArray) {
+		
+		return array_pop($filePathArray);
+	}
+	
+	
+	/**
+	 * @param $categoryId
+	 * @return string
+	 */
+	public function getCategoryName ($categoryId) {
+		
+		$categoryName = "";
+		if ($categoryId > 0) {
+			$categoryObj = $this->modx->getObject('modCategory', $categoryId);
+			if (is_object($categoryObj)){
+				$categoryName = $categoryObj->get('category');
+			}
+		}
+		
+		return $categoryName;
+	}
+	
+	
 	/**
 	 * @param $path
 	 * @return array
 	 */
 	public function scanElementsDirectory($path) {
-
+		
 		$files = array();
 		$this->_scanFolder($path, $files);
-
+		
 		return $files;
 	}
-
-
+	
+	
 	/**
 	 * @param $path
 	 * @param $files
 	 */
 	private function _scanFolder($path, &$files) {
-
+		
 		$directory = new RecursiveDirectoryIterator($path);
 		foreach(new RecursiveIteratorIterator($directory) as $filename => $file) {
 			$rest = substr($filename, -2);
@@ -453,140 +466,140 @@ class Seaccelerator {
 			}
 		}
 	}
-
-
+	
+	
 	/**
 	 * @param $file
 	 * @param $elementModClass
 	 * @return bool
 	 */
 	private function _isElementStatic($file, $elementModClass) {
-
+		
 		if(is_object($this->getStaticElement($file, $elementModClass))) {
 			return true;
 		} else {
-     return false;
-    }
+			return false;
+		}
 	}
-
-
-  /**
-   * @param $filename
-   * @return mixed
-   */
+	
+	
+	/**
+	 * @param $filename
+	 * @return mixed
+	 */
 	public function getElementClass($filename) {
-
+		
 		$elementFileRules = $this->elementFileRules;
-
-    if (is_array($filename)) {
-      $elementDirectory = array_pop(array_filter($filename));
-    } else {
-      $elementDirectory = $filename;
-    }
-
-    foreach ($elementFileRules as $rule) {
-      $elementRule = explode(":", $rule);
-      if ($elementDirectory == $elementRule[1]) {
-        return $elementRule[0];
-      }
-    }
+		
+		if (is_array($filename)) {
+			$elementDirectory = array_pop(array_filter($filename));
+		} else {
+			$elementDirectory = $filename;
+		}
+		
+		foreach ($elementFileRules as $rule) {
+			$elementRule = explode(":", $rule);
+			if ($elementDirectory == $elementRule[1]) {
+				return $elementRule[0];
+			}
+		}
 	}
-
-
-  /**
-   * @param $filenameOrModClass
-   * @return mixed
-   */
-  public function getElementDirectory($filenameOrModClass) {
-
-    $elementFileRules = $this->elementFileRules;
-
-    if (is_array($filenameOrModClass)) {
-      $elementDirectory = array_pop($filenameOrModClass);
-    } else {
-      $elementDirectory = $filenameOrModClass;
-    }
-
-    foreach ($elementFileRules as $rule) {
-      $elementRule = explode(":", $rule);
-      if ($elementDirectory == $elementRule[0]) {
-        return $elementRule[1];
-      } else if ($elementDirectory == $elementRule[1]) {
-        return $elementRule[1];
-      }
-    }
-  }
-
-
+	
+	
+	/**
+	 * @param $filenameOrModClass
+	 * @return mixed
+	 */
+	public function getElementDirectory($filenameOrModClass) {
+		
+		$elementFileRules = $this->elementFileRules;
+		
+		if (is_array($filenameOrModClass)) {
+			$elementDirectory = array_pop($filenameOrModClass);
+		} else {
+			$elementDirectory = $filenameOrModClass;
+		}
+		
+		foreach ($elementFileRules as $rule) {
+			$elementRule = explode(":", $rule);
+			if ($elementDirectory == $elementRule[0]) {
+				return $elementRule[1];
+			} else if ($elementDirectory == $elementRule[1]) {
+				return $elementRule[1];
+			}
+		}
+	}
+	
+	
 	/**
 	 * @param $elementModClass
 	 * @return string
 	 */
 	private function _convertModElementClassToType($elementModClass) {
-
+		
 		return ucfirst(str_replace("mod", "", $elementModClass));
 	}
-
-
+	
+	
 	/**
 	 * @param $filenameWithSuffix
 	 * @return mixed
 	 */
 	public function makeElementName($filenameWithSuffix) {
-
+		
 		$filenameArr = explode(".", $filenameWithSuffix);
-
+		
 		return $filenameArr[0];
 	}
-
-
+	
+	
 	/**
 	 * @param $file
 	 * @param $elementModClass
 	 * @return null|object
 	 */
 	public function getStaticElement($file, $elementModClass) {
-
+		
 		$parameter = array(
 			"static" => 1
-		,"static_file:LIKE" => "%".$file."%",
+			,"static_file:LIKE" => "%".$file."%",
 		);
 		$element = $this->modx->getObject($elementModClass, $parameter);
-
+		
 		return $element;
 	}
-
-
+	
+	
 	/**
 	 * @param $type
 	 * @return string
 	 */
 	public function getElementFieldName($type) {
-
+		
 		if($type == "modTemplate" || $type == "template") {
 			$elementFieldName = "templatename";
 		} else {
 			$elementFieldName = "name";
 		}
-
+		
 		return $elementFieldName;
 	}
-
-
+	
+	
 	/**
 	 * @param $category
 	 * @return string
 	 */
 	public function parseCategory($category) {
-
+		
 		$idCategory = 0;
 		if($category == 0) {
 			return $idCategory;
 		} else {
-      if (!is_array($category)) {
-        $category = explode("/", $category);
-      }
-
+			if (!is_array($category)) {
+				$category = explode("/", $category);
+			}
+			
 			//array_pop($category);
 			$parentId = 0;
 			for($i = 0; $i < sizeof($category); $i++) {
@@ -594,7 +607,7 @@ class Seaccelerator {
 				if($currentCategory) {
 					$idCategory = $currentCategory->id;
 					$parentId = $currentCategory->id;
-
+					
 				} else {
 					$newCategory = $this->modx->newObject("modCategory");
 					$newCategory->set("parent", $parentId);
@@ -605,155 +618,155 @@ class Seaccelerator {
 				}
 			}
 		}
-
+		
 		return $idCategory;
 	}
-
-
-  /**
-   * @param $categoryId
-   * @return int|string
-   */
-  public function parseCategoryToPath($categoryId) {
-
-    if ($categoryId == 0) return;
-
-    $categories = $this->modx->getCollection('modCategory');
-    $list = [];
-    foreach ($categories as $category) {
-      $list[$category->id] = array (
-        'parent' => $category->parent,
-        'name' => $category->category
-      );
-    }
-    $this->_getParents($categoryId, array(), $list);
-    $parentsMap = join('/', array_reverse($this->map)) . "/";
-
-    return $parentsMap;
-  }
-
-
-  /**
-   * @param $filePathArray
-   * @param $elementDirectory
-   * @return array
-   */
-  public function prepareCategories($filePathArray, $elementDirectory) {
-
-    array_shift($filePathArray);
-    $separateElementTypeBy = $this->modx->getOption("seaccelerator.element_type_separation", null, "folder");
-
-    $categories = array_reverse($filePathArray);
-    if ($separateElementTypeBy == "folder") {
-      $elementDirectory = str_replace("/", "", $elementDirectory);
-      if ($categories[0] == $elementDirectory) {
-        array_shift($categories);
-      }
-    }
-
-    return $categories;
-  }
-
-
-  /**
-   * @param $id
-   * @param array $parents
-   * @param array $categoryList
-   */
-  private function _getParents($id, array $parents, array $categoryList) {
-
-    $parents[] = $categoryList[$id]['name'];
-    $parent = $categoryList[$id]['parent'];
-    if ($parent != 0) {
-      $this->_getParents($parent, $parents, $categoryList);
-    } else {
-      $this->map = $parents;
-    }
-  }
-
-
+	
+	
+	/**
+	 * @param $categoryId
+	 * @return int|string
+	 */
+	public function parseCategoryToPath($categoryId) {
+		
+		if ($categoryId == 0) return;
+		
+		$categories = $this->modx->getCollection('modCategory');
+		$list = [];
+		foreach ($categories as $category) {
+			$list[$category->id] = array (
+				'parent' => $category->parent,
+				'name' => $category->category
+			);
+		}
+		$this->_getParents($categoryId, array(), $list);
+		$parentsMap = join('/', array_reverse($this->map)) . "/";
+		
+		return $parentsMap;
+	}
+	
+	
+	/**
+	 * @param $filePathArray
+	 * @param $elementDirectory
+	 * @return array
+	 */
+	public function prepareCategories($filePathArray, $elementDirectory) {
+		
+		array_shift($filePathArray);
+		$separateElementTypeBy = $this->modx->getOption("seaccelerator.element_type_separation", null, "folder");
+		
+		$categories = array_reverse($filePathArray);
+		if ($separateElementTypeBy == "folder") {
+			$elementDirectory = str_replace("/", "", $elementDirectory);
+			if ($categories[0] == $elementDirectory) {
+				array_shift($categories);
+			}
+		}
+		
+		return $categories;
+	}
+	
+	
+	/**
+	 * @param $id
+	 * @param array $parents
+	 * @param array $categoryList
+	 */
+	private function _getParents($id, array $parents, array $categoryList) {
+		
+		$parents[] = $categoryList[$id]['name'];
+		$parent = $categoryList[$id]['parent'];
+		if ($parent != 0) {
+			$this->_getParents($parent, $parents, $categoryList);
+		} else {
+			$this->map = $parents;
+		}
+	}
+	
+	
 	/**
 	 * @param array $files
 	 * @return bool
 	 */
 	public function createMultipleElements(array $files = array()) {
-
+		
 		if(!$files) {
 			$files = $this->getNewFiles();
 		}
-
+		
 		$result = false;
 		foreach($files as $file) {
-
-      // TODO: Create method
-      $filePathArray = $this->getFilePathAsArray($file['file']);
-      $elementModClass = $this->getElementClass($filePathArray);
-      $elementDirectory = $this->getElementDirectory($filePathArray);
-      $categories = $this->prepareCategories($filePathArray, $elementDirectory);
-
+			
+			// TODO: Create method
+			$filePathArray = $this->getFilePathAsArray($file['file']);
+			$elementModClass = $this->getElementClass($filePathArray);
+			$elementDirectory = $this->getElementDirectory($filePathArray);
+			$categories = $this->prepareCategories($filePathArray, $elementDirectory);
+			
 			$elementData = $this->makeElementDataArray($categories, $file["filename"], $file["path"], $elementModClass, $file["mediasource"]);
 			$elementObj  = $this->modx->newObject($elementModClass);
-      if (is_object($elementObj)) {
-        $result = $this->setAsStaticElement($elementObj, $elementData, false);
-      }
+			if (is_object($elementObj)) {
+				$result = $this->setAsStaticElement($elementObj, $elementData, false);
+			}
 		}
-
+		
 		return $result;
 	}
-
-
+	
+	
 	/**
 	 * @param $fileName
 	 * @param $filePath
 	 * @return bool
 	 */
 	public function createSingleElement($fileName, $filePath) {
-
-    // TODO: Create method
-		$file = $filePath.$fileName;
+		
+		// TODO: Create method
+		$file = str_replace( $this->getElementsDirectory(), '', $filePath ) .$fileName;
 		$filePathArray = $this->getFilePathAsArray($file);
-    $elementModClass = $this->getElementClass($filePathArray);
-    $elementDirectory = $this->getElementDirectory($filePathArray);
-    $categories = $this->prepareCategories($filePathArray, $elementDirectory);
-
-    $isStatic = $this->_isElementStatic($file, $elementModClass);
-    $isNewFile = false;
-    $result = false;
-
-    if($isStatic == false) {
+		$elementModClass = $this->getElementClass($filePathArray);
+		$elementDirectory = $this->getElementDirectory($filePathArray);
+		$categories = $this->prepareCategories($filePathArray, $elementDirectory);
+		
+		$isStatic = $this->_isElementStatic($file, $elementModClass);
+		$isNewFile = false;
+		$result = false;
+		
+		if($isStatic == false) {
 			$mediaSourceId = $this->modx->getOption("seaccelerator.mediasource", null, true);
 			$elementData 	 = $this->makeElementDataArray($categories, $fileName, $filePath, $elementModClass, $mediaSourceId);
 			$elementObj    = $this->modx->newObject($elementModClass);
-      if (is_object($elementObj)) {
-        $result = $this->setAsStaticElement($elementObj, $elementData, $isNewFile);
-      }
+			if (is_object($elementObj)) {
+				$result = $this->setAsStaticElement($elementObj, $elementData, $isNewFile);
+			}
 		}
-
+		
 		return $result;
 	}
-
-
-  /**
-   * @param $filePath
-   * @return mixed
-   */
-  public function removeElementDirectory($filePath) {
-
-    $category = str_replace("", "", $filePath);
-
-    return $category;
-  }
-
-
+	
+	
+	/**
+	 * @param $filePath
+	 * @return mixed
+	 */
+	public function removeElementDirectory($filePath) {
+		
+		$category = str_replace("", "", $filePath);
+		
+		return $category;
+	}
+	
+	
 	/**
 	 * @param $staticFile
 	 * @param $mediaSource
 	 * @return bool
 	 */
 	public function deleteFile($staticFile, $mediaSource = 1) {
-
+		
 		$file = $this->makeStaticElementFilePath('', $staticFile, $mediaSource, true);
-
+		
 		if($file) {
 			unlink($file);
 			return true;
@@ -761,26 +774,26 @@ class Seaccelerator {
 			return false;
 		}
 	}
-
-
+	
+	
 	/**
 	 * @param $id
 	 * @param $elementModClass
 	 * @return bool
 	 */
 	public function deleteElement($id, $elementModClass) {
-
+		
 		$element = $this->modx->getObject($elementModClass, $id);
 		if($element) {
 			$result = $element->remove();
 		} else {
 			$result = false;
 		}
-
+		
 		return $result;
 	}
-
-
+	
+	
 	/**
 	 * @param $id
 	 * @param $staticFile
@@ -789,103 +802,103 @@ class Seaccelerator {
 	 * @return bool
 	 */
 	public function deleteElementAndFile($id, $staticFile, $mediaSource, $elementModClass) {
-
+		
 		$result = $this->deleteElement($id, $elementModClass);
 		if ($result) {
 			$result = $this->deleteFile($staticFile, $mediaSource);
 		}
-
+		
 		return $result;
 	}
-
-
-  /**
-   * @param $elementData
-   * @return bool|mixed
-   */
-  public function exportElementAsStatic($elementData) {
-
-    $parameter = array("id" => $elementData['id']);
-    $elementObj = $this->modx->getObject($elementData['modClass'], $parameter);
-    if (is_object($elementObj)) {
-
-      //$elementArr = $elementObj->toArray();
-      //$this->modx->log(xPDO::LOG_LEVEL_DEBUG, $elementArr);
-      //$elementData['path']
-
-      // TODO: One method that handles the files. Input: filename, category, source. Method will return the needed paths.
-      $elementCategory = $this->parseCategoryToPath($elementData["category_id"]);
-      $elementDirectory = $this->getElementDirectory($elementData['modClass']);
-
-      $fileSuffix = $this->getFileSuffix($elementData['modClass']);
-      $fileName = $elementData['name'].$fileSuffix;
-      $filePath = $elementDirectory . "/" . $elementCategory;
-
-      // TODO: Logic for default media source
-      $elementData["source"] = $this->defaultMediaSource;
-      $elementData["content"] = $elementObj->get("content");
-
-      //$elementData["name"] = $element->get("name");
-      //$elementData["content"] = $element->get("content");
-      // TODO: This method is deprecated
-      $elementData["folder"] = $this->getElementsLocationFilesystemPath();
-      $elementData["file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], true);
-      $elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], false);;
-      $elementIsNewFile = true;
-      $result = $this->setAsStaticElement($elementObj, $elementData, $elementIsNewFile);
-
-    } else {
-      $result = false;
-    }
-
-    return $result;
-  }
-
-
+	
+	
+	/**
+	 * @param $elementData
+	 * @return bool|mixed
+	 */
+	public function exportElementAsStatic($elementData) {
+		
+		$parameter = array("id" => $elementData['id']);
+		$elementObj = $this->modx->getObject($elementData['modClass'], $parameter);
+		if (is_object($elementObj)) {
+			
+			//$elementArr = $elementObj->toArray();
+			//$this->modx->log(xPDO::LOG_LEVEL_DEBUG, $elementArr);
+			//$elementData['path']
+			
+			// TODO: One method that handles the files. Input: filename, category, source. Method will return the needed paths.
+			$elementCategory = $this->parseCategoryToPath($elementData["category_id"]);
+			$elementDirectory = $this->getElementDirectory($elementData['modClass']);
+			
+			$fileSuffix = $this->getFileSuffix($elementData['modClass']);
+			$fileName = $elementData['name'].$fileSuffix;
+			$filePath = $elementDirectory . "/" . $elementCategory;
+			
+			// TODO: Logic for default media source
+			$elementData["source"] = $this->defaultMediaSource;
+			$elementData["content"] = $elementObj->get("content");
+			
+			//$elementData["name"] = $element->get("name");
+			//$elementData["content"] = $element->get("content");
+			// TODO: This method is deprecated
+			$elementData["folder"] = $this->getElementsLocationFilesystemPath();
+			$elementData["file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], true);
+			$elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], false);;
+			$elementIsNewFile = true;
+			$result = $this->setAsStaticElement($elementObj, $elementData, $elementIsNewFile);
+			
+		} else {
+			$result = false;
+		}
+		
+		return $result;
+	}
+	
+	
 	/**
 	 * @param $elementType
 	 * @return array
 	 */
 	public function exportElementsAsStatic($elementType) {
-
+		
 		$modObjectType = $this->modElementClasses[$elementType][0];
 		$parameter = array("static" => 0);
 		$elements = $this->modx->getCollection($modObjectType, $parameter);
-
+		
 		$result = [];
 		$elementsFolder = $this->getElementsLocationFilesystemPath();
 		$suffix = $this->getFileSuffix($elementType);
-
+		
 		foreach($elements as $elementObj) {
 			$name = $elementObj->get("name");
 			$elementData["name"] = $elementObj->get("name");
 			$elementData["content"] = $elementObj->get("content");
-
+			
 			if (!empty($elementData["name"]) && !empty($elementData["content"])) {
 				$elementData["file"] = $elementsFolder.$elementType."/".$name.$suffix;
 				$result = $this->setAsStaticElement($elementObj, $elementData, true);
 			}
 		}
-
+		
 		return $result;
 	}
-
-
-  /**
-   * @param $elementData
-   * @return mixed
-   */
-  public function updateChunkFromStaticFile($elementData) {
-
-    $file = $this->makeStaticElementFilePath($elementData["file"], $elementData["path"], $elementData["source"], true);
-
-    $elementData["content"] = $this->getFileContent($file);
-    $elementObj = $this->modx->getObject($elementData["modClass"], $elementData["id"]);
-
-    return $this->saveElementObject($elementObj, $elementData, true);
-  }
-
-
+	
+	
+	/**
+	 * @param $elementData
+	 * @return mixed
+	 */
+	public function updateChunkFromStaticFile($elementData) {
+		
+		$file = $this->makeStaticElementFilePath($elementData["file"], $elementData["path"], $elementData["source"], true);
+		
+		$elementData["content"] = $this->getFileContent($file);
+		$elementObj = $this->modx->getObject($elementData["modClass"], $elementData["id"]);
+		
+		return $this->saveElementObject($elementObj, $elementData, true);
+	}
+	
+	
 	/**
 	 * @param $elementObj
 	 * @param $elementData
@@ -893,20 +906,20 @@ class Seaccelerator {
 	 * @return bool|mixed
 	 */
 	public function setAsStaticElement($elementObj, $elementData, $isNewFile) {
-
+		
 		$result = false;
 		if ($isNewFile) {
 			$result = $this->saveElementToFilesystem($elementData);
 		}
-
+		
 		if ($result !== false || !$isNewFile) {
 			$result = $this->saveElementObject($elementObj, $elementData, true);
 		}
-
+		
 		return $result;
 	}
-
-
+	
+	
 	/**
 	 * @param $elementObj
 	 * @param $elementData
@@ -914,46 +927,46 @@ class Seaccelerator {
 	 * @return bool|mixed
 	 */
 	public function unsetAsStaticElement($elementObj, $elementData, $elementType) {
-
+		
 		$result = $this->saveElementObject($elementObj, $elementType, false);
 		$file = $this->makeStaticElementFilePath($elementData["file"], $elementData["mediaSourceId"], $elementData["path"], true);
-
+		
 		if ($result) {
 			$result = $this->deleteFile($file);
 		}
-
+		
 		return $result;
 	}
-
-
+	
+	
 	/**
 	 * @param $elementData
 	 * @return bool
 	 */
 	public function saveElementToFilesystem($elementData) {
-
-    $result = file_put_contents($elementData["file"], $elementData["content"]);
+		
+		$result = file_put_contents($elementData["file"], $elementData["content"]);
 		if ($result === false) {
-      $parts = explode('/', $elementData["file"]);
-      $file = array_pop($parts);
-      if ($parts[0] == "") {
-        array_shift($part);
-      };
-      $dir = '';
-      foreach($parts as $part) {
-        if (!is_dir($dir .= "/$part")) mkdir($dir, 0644);
-      }
-      $result = file_put_contents("$dir/$file", $elementData["content"]);
-      if ($result !== false){
-        $result = true;
-      }
+			$parts = explode('/', $elementData["file"]);
+			$file = array_pop($parts);
+			if ($parts[0] == "") {
+				array_shift($part);
+			};
+			$dir = '';
+			foreach($parts as $part) {
+				if (!is_dir($dir .= "/$part")) mkdir($dir, 0644);
+			}
+			$result = file_put_contents("$dir/$file", $elementData["content"]);
+			if ($result !== false){
+				$result = true;
+			}
 		} else {
-      $result = true;
+			$result = true;
 		}
-    return $result;
+		return $result;
 	}
-
-
+	
+	
 	/**
 	 * @param $elementObj
 	 * @param $elementData
@@ -961,48 +974,48 @@ class Seaccelerator {
 	 * @return mixed
 	 */
 	public function saveElementObject($elementObj, $elementData, $static) {
-
-    $fieldName = $this->getElementFieldName($elementData["type"]);
-
+		
+		$fieldName = $this->getElementFieldName($elementData["type"]);
+		
 		$elementObj->set($fieldName, $elementData["name"]);
 		$elementObj->set("source", $elementData["source"]);
 		$elementObj->set("static_file", $elementData["static_file"]);
 		$elementObj->set("category", $elementData["categoryId"]);
 		$elementObj->set("content", $elementData["content"]);
 		$elementObj->set("static", $static);
-
+		
 		$result = $elementObj->save();
-
+		
 		return $result;
 	}
-
-
-  /**
-   * @param $elementObj
-   * @param $elementRecord
-   * @return mixed
-   */
-  public function updateElement($elementObj, $elementRecord) {
-
-    $elementData['name'] = $elementRecord['name'];
-    $elementData['source'] = $elementRecord['source'];
-    $elementData['static_file'] = $elementRecord['static_file'];
-    $elementData['category'] = $elementRecord['category'];
-    $elementData['content'] = $elementRecord['content'];
-    //$elementData['description'] = $elementRecord['description'];
-
-    $result = $this->saveElementObject($elementObj, $elementData, true);
-
-    return $result;
-  }
-
-
+	
+	
+	/**
+	 * @param $elementObj
+	 * @param $elementRecord
+	 * @return mixed
+	 */
+	public function updateElement($elementObj, $elementRecord) {
+		
+		$elementData['name'] = $elementRecord['name'];
+		$elementData['source'] = $elementRecord['source'];
+		$elementData['static_file'] = $elementRecord['static_file'];
+		$elementData['category'] = $elementRecord['category'];
+		$elementData['content'] = $elementRecord['content'];
+		//$elementData['description'] = $elementRecord['description'];
+		
+		$result = $this->saveElementObject($elementObj, $elementData, true);
+		
+		return $result;
+	}
+	
+	
 	/**
 	 * @param $type
 	 * @return mixed
 	 */
 	public function getFileSuffix($type) {
-
+		
 		if (strpos($type, "mod") !== false) {
 			$fileSuffixes = array(
 				"modChunk" => ".html",
@@ -1010,7 +1023,7 @@ class Seaccelerator {
 				"modSnippet" => ".php",
 				"modPlugin" => ".php"
 			);
-
+			
 		} else {
 			$fileSuffixes = array(
 				"chunks" => ".html",
@@ -1019,21 +1032,21 @@ class Seaccelerator {
 				"plugins" => ".php"
 			);
 		}
-
+		
 		return $fileSuffixes[$type];
 	}
-
-
+	
+	
 	/**
 	 * @param $file
 	 * @return bool|string
 	 */
 	private function getFileContent($file) {
-
+		
 		return file_get_contents($file, true);
 	}
-
-
+	
+	
 	/**
 	 * @param $file
 	 * @return string
@@ -1041,8 +1054,8 @@ class Seaccelerator {
 	public function getFileContentAsSHA1($file) {
 		return sha1_file($file);
 	}
-
-
+	
+	
 	/**
 	 * @param $file
 	 * @return string
@@ -1054,11 +1067,11 @@ class Seaccelerator {
 		} else {
 			$content = "";
 		}
-
+		
 		return $content;
 	}
-
-
+	
+	
 	/**
 	 * @param $category
 	 * @param $fileName
@@ -1068,74 +1081,74 @@ class Seaccelerator {
 	 * @return mixed
 	 */
 	public function makeElementDataArray($category, $fileName, $filePath, $elementModClass, $mediaSourceId) {
-
+		
 		$elementData["categoryId"]  = $this->parseCategory($category);
 		$elementData["name"] 			  = $this->makeElementName($fileName);
-    $elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $mediaSourceId, false);
-    $elementData["file"] 			  = $this->makeStaticElementFilePath($fileName, $filePath, $mediaSourceId, true);
-    $elementData["content"] 	  = $this->getFileContent($elementData['file']);
-    $elementData["type"]  		  = $elementModClass;
-    $elementData["source"]      = $mediaSourceId;
-
-    return $elementData;
+		$elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $mediaSourceId, false);
+		$elementData["file"] 			  = $this->makeStaticElementFilePath($fileName, $filePath, $mediaSourceId, true);
+		$elementData["content"] 	  = $this->getFileContent($elementData['file']);
+		$elementData["type"]  		  = $elementModClass;
+		$elementData["source"]      = $mediaSourceId;
+		
+		return $elementData;
 	}
-
-
+	
+	
 	/**
 	 * @param $results
 	 * @return mixed
 	 */
 	public function prepareElementGridData($results, $classKey) {
-
+		
 		foreach ($results as $result) {
 			$name = $result->get('name');
 			$filename = $this->makeFilename($name, $classKey);
-
+			
 			$elementData['name']  			= $name;
 			$elementData['filename']		= $filename;
 			$elementData['content']  		= $result->get('content');
 			$elementData['static_file'] = $result->get('static_file');
 			$elementData['static']  		= $result->get('static');
 			$elementData['source'] 			= $result->get('source');
-      //$elementData['category'] 		= $result->get('category');
-      $elementData['classKey'] 		= $classKey;
-
-      $result->set('category_name', $this->getCategoryName($result->get('category')));
+			//$elementData['category'] 		= $result->get('category');
+			$elementData['classKey'] 		= $classKey;
+			
+			$result->set('category_name', $this->getCategoryName($result->get('category')));
 			$result->set('status', $this->getElementStatusIcon($elementData));
 			$result->set('actions', $this->getElementActionIcons($elementData));
 		}
-
+		
 		return $results;
 	}
-
-
+	
+	
 	/**
 	 * @param $name
 	 * @param $classKey
 	 * @return string
 	 */
 	public function makeFilename($name, $classKey) {
-
+		
 		$suffix = $this->getFileSuffix($classKey);
-
+		
 		return $name.$suffix;
 	}
-
-
+	
+	
 	/**
 	 * @param $elementData
 	 * @return array
 	 */
 	public function checkElementStatus($elementData) {
-
+		
 		$status['path'] 	 = $elementData['path'];
 		$status['static']  = $elementData['static'];
 		$status['deleted'] = false;
 		$status['changed'] = false;
-
+		
 		// Element has an path and is static
 		if ($elementData['static'] == true && $elementData['static_file'] != "") {
-
+			
 			$path = str_replace($elementData['filename'], "", $elementData['static_file']);
 			$file = $this->makeStaticElementFilePath($elementData['filename'], $path, $elementData['source'], true);
 
@@ -1146,77 +1159,77 @@ class Seaccelerator {
 			if ($elementContentFilesystem == "") {
 				$status['deleted'] = true;
 			}
-
+			
 			// Has content changed?
 			if ($elementContentDatabase != $elementContentFilesystem) {
 				$status['changed'] = true;
 			}
 		}
-
+		
 		$elementStatus = $this->setElementStatusAndAction($status);
-
+		
 		return $elementStatus;
 	}
-
-
+	
+	
 	/**
 	 * @param $status
 	 * @return array
 	 */
 	public function setElementStatusAndAction($status) {
-
+		
 		$statusAndActions = [];
-
+		
 		if ($status['deleted'] == true) {
 			$statusAndActions['status'] = "deleted";
 			$statusAndActions['action'] = array("editElement", "syncToFile", "syncFromFileDisabled", "deleteElement", "deleteBothDisabled");
-
+			
 		} else if ($status['static'] == false) {
 			$statusAndActions['status'] = "static";
 			$statusAndActions['action'] = array("editElement", "syncToFile", "syncFromFileDisabled", "deleteElement", "deleteBothDisabled");
-
+			
 		} else if ($status['deleted'] == false && $status['changed'] == true) {
 			$statusAndActions['status'] = "changed";
 			$statusAndActions['action'] = array("editElement", "syncToFile", "syncFromFile", "deleteElement", "deleteBoth");
-
+			
 		} else if ($status['deleted'] == false && $status['changed'] == false) {
 			$statusAndActions['status'] = "unchanged";
 			$statusAndActions['action'] = array("editElement", "syncToFileDisabled", "syncFromFileDisabled", "deleteElement", "deleteBoth");
 		}
-
+		
 		return $statusAndActions;
 	}
-
-
+	
+	
 	/**
 	 * @param $elementData
 	 * @return mixed
 	 */
 	public function getElementStatusIcon($elementData) {
-
+		
 		$statusAndAction = $this->checkElementStatus($elementData);
-
+		
 		$statusIconRepository = array(
 			'changed' => '{"className":"exclamation-circle sm-orange","text":"'. $this->modx->lexicon('seaccelerator.elements.element_status.changed') .'"}',
 			'unchanged' => '{"className":"check-circle sm-green","text":"'. $this->modx->lexicon('seaccelerator.elements.element_status.unchanged') .'"}',
 			'deleted' => '{"className":"warning sm-red","text":"'. $this->modx->lexicon('seaccelerator.elements.element_status.deleted') .'"}',
 			'static' => '{"className":"info-circle sm-orange","text":"'. $this->modx->lexicon('seaccelerator.elements.element_status.not_static') .'"}'
 		);
-
+		
 		return json_decode($statusIconRepository[$statusAndAction['status']]);
 	}
-
-
+	
+	
 	/**
 	 * @param $elementData
 	 * @return array
 	 */
 	public function getElementActionIcons($elementData) {
-
+		
 		$statusAndActions = $this->checkElementStatus($elementData);
 		$actions = $statusAndActions['action'];
 		$actionIcons = [];
-
+		
 		$actionIconsRepository = array(
 			'editElement' =>   				 '{"className":"edit js_actionLink js_editElement","text":"'. $this->modx->lexicon('seaccelerator.elements.actions.quickupdate') .'"}',
 			'syncToFile' =>  	 				 '{"className":"arrow-circle-o-down js_actionLink js_syncToFile","text":"'. $this->modx->lexicon('seaccelerator.elements.actions.sync.tofile') .'"}',
@@ -1227,7 +1240,7 @@ class Seaccelerator {
 			'deleteBoth' => 	 				 '{"className":"trash js_actionLink js_deleteFileElement","text":"'. $this->modx->lexicon('seaccelerator.elements.actions.delete_file_element') .'"}',
 			'deleteBothDisabeld' => 	 '{"className":"trash disabled","text":"'. $this->modx->lexicon('seaccelerator.elements.actions.delete_file_element') .'"}',
 		);
-
+		
 		foreach ($actionIconsRepository as $actionIcon => $actionIconContent) {
 			foreach ($actions as $action) {
 				if ($action == $actionIcon) {
@@ -1235,26 +1248,26 @@ class Seaccelerator {
 				}
 			}
 		}
-
+		
 		return $actionIcons;
 	}
-
-
-  /**
-   * @param $results
-   * @return mixed
-   */
-  public function addCategoryName($results) {
-
-    foreach ($results as $result) {
-      $categoryId = $result->get('category');
-      $this->modx->log(xPDO::LOG_LEVEL_DEBUG, $categoryId);
-      //$category = $this->getCategoryName($categoryId);
-      //$result->set('category', $category);
-    }
-
-    return $results;
-  }
-
-
+	
+	
+	/**
+	 * @param $results
+	 * @return mixed
+	 */
+	public function addCategoryName($results) {
+		
+		foreach ($results as $result) {
+			$categoryId = $result->get('category');
+			$this->modx->log(xPDO::LOG_LEVEL_DEBUG, $categoryId);
+			//$category = $this->getCategoryName($categoryId);
+			//$result->set('category', $category);
+		}
+		
+		return $results;
+	}
+	
+	
 }

--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -200,18 +200,31 @@ class Seaccelerator {
 	}
 	
 	/**
+	 * Gets the full filesystem path to the Elements root folder.
+	 *
 	 * @return string
 	 */
 	public function getElementsLocationFilesystemPath() {
-
-		$mediaSourceId = $this->getElementsMediaSource();
 		$elementsDirectory = $this->getElementsDirectory();
-		if($mediaSourceId == 1) {
-			$elementsPath = MODX_BASE_PATH . $this->getMediaSourcePath($elementsDirectory, $mediaSourceId);
-		} else if ($mediaSourceId > 1) {
-			$elementsPath = MODX_BASE_PATH . $this->getMediaSourcePath($elementsDirectory, $mediaSourceId);
+		
+		return $this->getBaseFilesystemPath() . $elementsDirectory;
+	}
+	
+	/**
+	 * Gets the full filesystem path to the root folder in which the elements_directory resides.
+	 *
+	 * If there is a MediaSource defined, it is the root path of the MediaSource. Otherwise it uses the MODX_ASSETS_PATH
+	 * as a default.
+	 *
+	 * @return string
+	 */
+	public function getBaseFilesystemPath() {
+		
+		$mediaSourceId = $this->getElementsMediaSource();
+		if($mediaSourceId >= 1) {
+			$elementsPath = MODX_BASE_PATH . $this->getMediaSourcePath('', $mediaSourceId);
 		} else {
-			$elementsPath = MODX_ASSETS_PATH.$elementsDirectory;
+			$elementsPath = MODX_ASSETS_PATH;
 		}
 
 		return $elementsPath;

--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -22,14 +22,14 @@
  * @package seaccelerator
  */
 class Seaccelerator {
-	
+
 	public $modx = null;
 	public $map = array();
 	public $config = array();
-	public $elementFileRules;
-	public $defaultMediaSource;
-	
-	
+  public $elementFileRules;
+  public $defaultMediaSource;
+
+
 	/**
 	 * Constructs the Seaccelerator object
 	 *
@@ -38,33 +38,33 @@ class Seaccelerator {
 	 */
 	function __construct(modX &$modx,array $config = array()) {
 		$this->modx =& $modx;
-		
+
 		$basePath = $this->modx->getOption("seaccelerator.core_path", null, $this->modx->getOption("core_path")."components/seaccelerator/");
 		$assetsUrl = $this->modx->getOption("seaccelerator.assets_url", null, $this->modx->getOption("assets_url")."components/seaccelerator/");
-		
+
 		$this->config = array_merge(array(
-			                            "basePath" => $basePath,
-			                            "corePath" => $basePath,
-			                            "modelPath" => $basePath."model/",
-			                            "processorsPath" => $basePath."processors/",
-			                            "templatesPath" => $basePath."templates/",
-			                            "chunksPath" => $basePath."elements/chunks/",
-			                            "jsUrl" => $assetsUrl."js/",
-			                            "cssUrl" => $assetsUrl."css/",
-			                            "assetsUrl" => $assetsUrl,
-			                            "connectorUrl" => $assetsUrl."connector.php",
-		                            ),$config);
-		
-		$this->elementFileRules = explode(",", $this->modx->getOption("seaccelerator.element_type_rules", null, "modChunk:chunks,modSnippet:snippets,modTemplate:templates,modPlugin:plugins"));
-		$this->defaultMediaSource = $this->modx->getOption("seaccelerator.mediasource", null, 1);
-		
+			"basePath" => $basePath,
+			"corePath" => $basePath,
+			"modelPath" => $basePath."model/",
+			"processorsPath" => $basePath."processors/",
+			"templatesPath" => $basePath."templates/",
+			"chunksPath" => $basePath."elements/chunks/",
+			"jsUrl" => $assetsUrl."js/",
+			"cssUrl" => $assetsUrl."css/",
+			"assetsUrl" => $assetsUrl,
+			"connectorUrl" => $assetsUrl."connector.php",
+		),$config);
+
+    $this->elementFileRules = explode(",", $this->modx->getOption("seaccelerator.element_type_rules", null, "modChunk:chunks,modSnippet:snippets,modTemplate:templates,modPlugin:plugins"));
+    $this->defaultMediaSource = $this->modx->getOption("seaccelerator.mediasource", null, 1);
+
 		$this->modx->addPackage("seaccelerator",$this->config["modelPath"]);
-		
-		if ($this->modx->lexicon) {
-			$this->modx->lexicon->load ('seaccelerator:default');
-		}
+
+    if ($this->modx->lexicon) {
+      $this->modx->lexicon->load ('seaccelerator:default');
+    }
 	}
-	
+
 	/**
 	 * Initializes the class into the proper context
 	 *
@@ -75,7 +75,7 @@ class Seaccelerator {
 		switch($ctx) {
 			case "mgr":
 				$this->modx->lexicon->load("seaccelerator:default");
-				
+
 				if(!$this->modx->loadClass("seacceleratorControllerRequest",$this->config["modelPath"]."seaccelerator/request/",true,true)) {
 					return "Could not load controller request handler.";
 				}
@@ -83,28 +83,28 @@ class Seaccelerator {
 				return $this->request->handleRequest();
 				break;
 		}
-		
+
 		return true;
 	}
-	
-	
+
+
 	/**
 	 * @return mixed
 	 */
 	public function getElementsMediaSource() {
-		
+
 		$mediaSourceId = $this->modx->getOption("seaccelerator.mediasource", null, 1);
-		
+
 		return $mediaSourceId;
 	}
-	
-	
+
+
 	/**
 	 * @param $mediaSourceId
 	 * @return bool
 	 */
 	public function getMediaSourceName($mediaSourceId) {
-		
+
 		$mediaSource = $this->modx->getObject("sources.modMediaSource", $mediaSourceId);
 		if(!empty($mediaSource) && is_object($mediaSource)) {
 			return $mediaSource->get("name");
@@ -112,14 +112,14 @@ class Seaccelerator {
 			return false;
 		}
 	}
-	
-	
+
+
 	/**
 	 * @param $results
 	 * @return mixed
 	 */
 	public function getMediaSourceNameFromArray ($results) {
-		
+
 		foreach ($results as $result) {
 			$source = $result->get("source");
 			$mediaSource = $this->modx->getObject('sources.modMediaSource', $source);
@@ -130,28 +130,28 @@ class Seaccelerator {
 			}
 			$result->set("mediasource", $mediaSourceName);
 		}
-		
+
 		return $results;
 	}
-	
-	
-	/**
-	 * @return string
-	 */
-	public function getMediaSources() {
-		
-		$mediaSources = $this->modx->getObject('sources.modMediaSource');
-		foreach ($mediaSources as $source) {
-			$sources[] = array(
-				"id" => $source->get("id"),
-				"name" => $source->get("name")
-			);
-		}
-		
-		return $this->modx->toJSON($sources);
-	}
-	
-	
+
+
+  /**
+   * @return string
+   */
+  public function getMediaSources() {
+
+    $mediaSources = $this->modx->getObject('sources.modMediaSource');
+    foreach ($mediaSources as $source) {
+      $sources[] = array(
+          "id" => $source->get("id"),
+          "name" => $source->get("name")
+      );
+    }
+
+    return $this->modx->toJSON($sources);
+  }
+
+
 	/**
 	 * Prepends the elementsPath with the path to a given MediaSource
 	 *
@@ -160,32 +160,32 @@ class Seaccelerator {
 	 * @return mixed
 	 */
 	public function getMediaSourcePath($elementsPath, $mediaSourceId) {
-		
+
 		$mediaSource = $this->modx->getObject("sources.modMediaSource", array('id' => $mediaSourceId));
 		if(!empty($mediaSource) && is_object($mediaSource)) {
 			$elementsPath = $mediaSource->prepareOutputUrl($elementsPath);
 		}
-		
+
 		return $elementsPath;
 	}
-	
-	
+
+
 	/**
 	 * @param $mediaSourceName
 	 * @return int
 	 */
 	public function getMediaSourceId($mediaSourceName) {
-		
-		$c = $this->modx->newQuery('sources.modMediaSource');
-		$c->where(array('name' => $mediaSourceName));
-		$mediaSources = $this->modx->getCollectionGraph("sources.modMediaSource", $c);
-		
+
+    $c = $this->modx->newQuery('sources.modMediaSource');
+    $c->where(array('name' => $mediaSourceName));
+    $mediaSources = $this->modx->getCollectionGraph("sources.modMediaSource", $c);
+
 		if(is_object($mediaSources)) {
-			$mediaSourceId = $mediaSources->get("id");
+      $mediaSourceId = $mediaSources->get("id");
 		} else {
 			$mediaSourceId = 1;
 		}
-		
+
 		return $mediaSourceId;
 	}
 	
@@ -243,43 +243,43 @@ class Seaccelerator {
 		} else {
 			$elementsPath = MODX_ASSETS_PATH;
 		}
-		
+
 		return $elementsPath;
 	}
-	
-	
+
+
 	/**
 	 * @return array
 	 */
 	public function getNewFiles() {
-		
+
 		$actionCreateElement = json_decode('{"className":"check-square-o js_actionLink js_createElement","text":"'. $this->modx->lexicon('seaccelerator.files.actions.create') .'"}');
 		$actionEditFile = json_decode('{"className":"edit js_actionLink js_editFile","text":"' .$this->modx->lexicon('seaccelerator.files.actions.edit_file') .'"}');
 		$actionDeleteFile = json_decode('{"className":"trash js_actionLink js_deleteFile","text":"' .$this->modx->lexicon('seaccelerator.files.actions.delete_file') .'"}');
-		
+
 		$actions = array($actionCreateElement, $actionEditFile, $actionDeleteFile);
-		
+
 		$newFiles = array();
 		$elementsPath = $this->getElementsLocationFilesystemPath();
 		$filesystem = $this->scanElementsDirectory($elementsPath);
-		
+
 		foreach($filesystem as $file) {
 			$filePathArray = $this->getFilePathAsArray($file);
 			$fileName = array_shift ($filePathArray);
 			$elementModClass = $this->getElementClass($filePathArray);
-			
+
 			if(!$this->_isElementStatic($fileName, $elementModClass)) {
 				$mediaSourceId = $this->getElementsMediaSource();
 				$mediaSourceName = $this->getMediaSourceName($mediaSourceId);
 				$category = $this->getElementCategoryFromFilesystem($filePathArray);
 				$type = $this->_convertModElementClassToType($elementModClass);
-				
+
 				if($mediaSourceId > 0) {
 					$filePathString = $this->getElementsDirectory() . $this->convertFilePathToString($filePathArray);
 				} else {
 					$filePathString = $elementsPath.$this->convertFilePathToString($filePathArray);
 				}
-				
+
 				$newFiles[] = array(
 					"file" => $file,
 					"filename" => $fileName,
@@ -293,40 +293,39 @@ class Seaccelerator {
 				);
 			}
 		}
-		
+
 		return $newFiles;
 	}
-	
-	
+
+
 	/**
 	 * @param $filePathArray
 	 * @return string
 	 */
 	public function convertFilePathToString($filePathArray) {
-		
-		$filePathString = implode("/", array_reverse(array_filter($filePathArray)));
+
+    $filePathString = implode("/", array_reverse(array_filter($filePathArray)));
 		if (substr($filePathString, -1, 1) != "/") {
 			$filePathString = $filePathString."/";
 		}
-		
+
 		return $filePathString;
 	}
-	
-	
+
+
 	/**
 	 * @param $fileNameString
 	 * @return array
 	 */
 	public function getFilePathAsArray($fileNameString) {
-		
+
 		$elementsPath = $this->getElementsLocationFilesystemPath();
 		$filePath = array_reverse(explode("/", str_replace($elementsPath, "", $fileNameString)));
-		
+
 		return $filePath;
 	}
-	
-	
-	// The static element file_path attribute is relative to the Media Source folder path, and contains no starting slash
+
+
 	/**
 	 * @param $fileName
 	 * @param $file
@@ -335,20 +334,20 @@ class Seaccelerator {
 	 * @return string
 	 */
 	public function makeStaticElementFilePath($fileName, $file, $mediaSource, $makeFullPath) {
-		
+
 		if ($fileName == '') {
-			//$filePathArray = $this->getFilePathAsArray($file);
-			$filePathArray = $this->getFilePathAsArray($file);
-			$fileName = array_shift($filePathArray);
-			$filePath = $this->convertFilePathToString($filePathArray);
+      //$filePathArray = $this->getFilePathAsArray($file);
+      $filePathArray = $this->getFilePathAsArray($file);
+      $fileName = array_shift($filePathArray);
+      $filePath = $this->convertFilePathToString($filePathArray);
 		} else {
 			$filePath = $file;
 		}
-		
+
 		if (!is_numeric($mediaSource)) {
-			$mediaSourceId = $this->getMediaSourceId($mediaSource);
-		} else if ($mediaSource == 0) {
-			$mediaSourceId = $this->defaultMediaSource;
+      $mediaSourceId = $this->getMediaSourceId($mediaSource);
+    } else if ($mediaSource == 0) {
+      $mediaSourceId = $this->defaultMediaSource;
 		} else {
 			$mediaSourceId = $mediaSource;
 		}
@@ -364,34 +363,34 @@ class Seaccelerator {
 		$staticElementFilePath = str_replace("//", "/", $staticElementFilePath);
 		return $staticElementFilePath;
 	}
-	
-	
+
+
 	/**
 	 * @param $fileName
 	 * @param $filePath
 	 * @return string
 	 */
 	public function makeFilesystemPath($fileName, $filePath) {
-		
+
 		$file = MODX_BASE_PATH.$filePath."/".$fileName;
-		
+
 		return $file;
 	}
-	
-	
-	public function saveStaticElement($elementObject) {
-	
-	}
-	
-	
-	/**
-	 * @param $filePathArray
-	 * @return int|mixed
-	 */
+
+
+  public function saveStaticElement($elementObject) {
+
+  }
+
+
+  /**
+   * @param $filePathArray
+   * @return int|mixed
+   */
 	public function getElementCategoryFromFilesystem($filePathArray) {
-		
-		$filePathArray = array_merge(array_filter($filePathArray));
-		
+
+    $filePathArray = array_merge(array_filter($filePathArray));
+
 		$useCategories = $this->modx->getOption("seaccelerator.use_categories", null, true);
 		if($useCategories) {
 			$fullCategory = array_reverse($filePathArray);
@@ -406,58 +405,58 @@ class Seaccelerator {
 		} else {
 			$category = 0;
 		}
-		
+
 		return $category;
 	}
-	
-	
-	/**
-	 * @param $filePathArray
-	 * @return mixed
-	 */
-	public function getElementCategoryPathFromFilesystem($filePathArray) {
-		
-		return array_pop($filePathArray);
-	}
-	
-	
-	/**
-	 * @param $categoryId
-	 * @return string
-	 */
-	public function getCategoryName ($categoryId) {
-		
-		$categoryName = "";
-		if ($categoryId > 0) {
-			$categoryObj = $this->modx->getObject('modCategory', $categoryId);
-			if (is_object($categoryObj)){
-				$categoryName = $categoryObj->get('category');
-			}
-		}
-		
-		return $categoryName;
-	}
-	
-	
+
+
+  /**
+   * @param $filePathArray
+   * @return mixed
+   */
+  public function getElementCategoryPathFromFilesystem($filePathArray) {
+
+    return array_pop($filePathArray);
+  }
+
+
+  /**
+   * @param $categoryId
+   * @return string
+   */
+  public function getCategoryName ($categoryId) {
+
+    $categoryName = "";
+    if ($categoryId > 0) {
+      $categoryObj = $this->modx->getObject('modCategory', $categoryId);
+      if (is_object($categoryObj)){
+        $categoryName = $categoryObj->get('category');
+      }
+    }
+
+    return $categoryName;
+  }
+
+
 	/**
 	 * @param $path
 	 * @return array
 	 */
 	public function scanElementsDirectory($path) {
-		
+
 		$files = array();
 		$this->_scanFolder($path, $files);
-		
+
 		return $files;
 	}
-	
-	
+
+
 	/**
 	 * @param $path
 	 * @param $files
 	 */
 	private function _scanFolder($path, &$files) {
-		
+
 		$directory = new RecursiveDirectoryIterator($path);
 		foreach(new RecursiveIteratorIterator($directory) as $filename => $file) {
 			$rest = substr($filename, -2);
@@ -466,140 +465,140 @@ class Seaccelerator {
 			}
 		}
 	}
-	
-	
+
+
 	/**
 	 * @param $file
 	 * @param $elementModClass
 	 * @return bool
 	 */
 	private function _isElementStatic($file, $elementModClass) {
-		
+
 		if(is_object($this->getStaticElement($file, $elementModClass))) {
 			return true;
 		} else {
-			return false;
-		}
+     return false;
+    }
 	}
-	
-	
-	/**
-	 * @param $filename
-	 * @return mixed
-	 */
+
+
+  /**
+   * @param $filename
+   * @return mixed
+   */
 	public function getElementClass($filename) {
-		
+
 		$elementFileRules = $this->elementFileRules;
-		
-		if (is_array($filename)) {
-			$elementDirectory = array_pop(array_filter($filename));
-		} else {
-			$elementDirectory = $filename;
-		}
-		
-		foreach ($elementFileRules as $rule) {
-			$elementRule = explode(":", $rule);
-			if ($elementDirectory == $elementRule[1]) {
-				return $elementRule[0];
-			}
-		}
+
+    if (is_array($filename)) {
+      $elementDirectory = array_pop(array_filter($filename));
+    } else {
+      $elementDirectory = $filename;
+    }
+
+    foreach ($elementFileRules as $rule) {
+      $elementRule = explode(":", $rule);
+      if ($elementDirectory == $elementRule[1]) {
+        return $elementRule[0];
+      }
+    }
 	}
-	
-	
-	/**
-	 * @param $filenameOrModClass
-	 * @return mixed
-	 */
-	public function getElementDirectory($filenameOrModClass) {
-		
-		$elementFileRules = $this->elementFileRules;
-		
-		if (is_array($filenameOrModClass)) {
-			$elementDirectory = array_pop($filenameOrModClass);
-		} else {
-			$elementDirectory = $filenameOrModClass;
-		}
-		
-		foreach ($elementFileRules as $rule) {
-			$elementRule = explode(":", $rule);
-			if ($elementDirectory == $elementRule[0]) {
-				return $elementRule[1];
-			} else if ($elementDirectory == $elementRule[1]) {
-				return $elementRule[1];
-			}
-		}
-	}
-	
-	
+
+
+  /**
+   * @param $filenameOrModClass
+   * @return mixed
+   */
+  public function getElementDirectory($filenameOrModClass) {
+
+    $elementFileRules = $this->elementFileRules;
+
+    if (is_array($filenameOrModClass)) {
+      $elementDirectory = array_pop($filenameOrModClass);
+    } else {
+      $elementDirectory = $filenameOrModClass;
+    }
+
+    foreach ($elementFileRules as $rule) {
+      $elementRule = explode(":", $rule);
+      if ($elementDirectory == $elementRule[0]) {
+        return $elementRule[1];
+      } else if ($elementDirectory == $elementRule[1]) {
+        return $elementRule[1];
+      }
+    }
+  }
+
+
 	/**
 	 * @param $elementModClass
 	 * @return string
 	 */
 	private function _convertModElementClassToType($elementModClass) {
-		
+
 		return ucfirst(str_replace("mod", "", $elementModClass));
 	}
-	
-	
+
+
 	/**
 	 * @param $filenameWithSuffix
 	 * @return mixed
 	 */
 	public function makeElementName($filenameWithSuffix) {
-		
+
 		$filenameArr = explode(".", $filenameWithSuffix);
-		
+
 		return $filenameArr[0];
 	}
-	
-	
+
+
 	/**
 	 * @param $file
 	 * @param $elementModClass
 	 * @return null|object
 	 */
 	public function getStaticElement($file, $elementModClass) {
-		
+
 		$parameter = array(
 			"static" => 1
-			,"static_file:LIKE" => "%".$file."%",
+		,"static_file:LIKE" => "%".$file."%",
 		);
 		$element = $this->modx->getObject($elementModClass, $parameter);
-		
+
 		return $element;
 	}
-	
-	
+
+
 	/**
 	 * @param $type
 	 * @return string
 	 */
 	public function getElementFieldName($type) {
-		
+
 		if($type == "modTemplate" || $type == "template") {
 			$elementFieldName = "templatename";
 		} else {
 			$elementFieldName = "name";
 		}
-		
+
 		return $elementFieldName;
 	}
-	
-	
+
+
 	/**
 	 * @param $category
 	 * @return string
 	 */
 	public function parseCategory($category) {
-		
+
 		$idCategory = 0;
 		if($category == 0) {
 			return $idCategory;
 		} else {
-			if (!is_array($category)) {
-				$category = explode("/", $category);
-			}
-			
+      if (!is_array($category)) {
+        $category = explode("/", $category);
+      }
+
 			//array_pop($category);
 			$parentId = 0;
 			for($i = 0; $i < sizeof($category); $i++) {
@@ -607,7 +606,7 @@ class Seaccelerator {
 				if($currentCategory) {
 					$idCategory = $currentCategory->id;
 					$parentId = $currentCategory->id;
-					
+
 				} else {
 					$newCategory = $this->modx->newObject("modCategory");
 					$newCategory->set("parent", $parentId);
@@ -618,155 +617,155 @@ class Seaccelerator {
 				}
 			}
 		}
-		
+
 		return $idCategory;
 	}
-	
-	
-	/**
-	 * @param $categoryId
-	 * @return int|string
-	 */
-	public function parseCategoryToPath($categoryId) {
-		
-		if ($categoryId == 0) return;
-		
-		$categories = $this->modx->getCollection('modCategory');
-		$list = [];
-		foreach ($categories as $category) {
-			$list[$category->id] = array (
-				'parent' => $category->parent,
-				'name' => $category->category
-			);
-		}
-		$this->_getParents($categoryId, array(), $list);
-		$parentsMap = join('/', array_reverse($this->map)) . "/";
-		
-		return $parentsMap;
-	}
-	
-	
-	/**
-	 * @param $filePathArray
-	 * @param $elementDirectory
-	 * @return array
-	 */
-	public function prepareCategories($filePathArray, $elementDirectory) {
-		
-		array_shift($filePathArray);
-		$separateElementTypeBy = $this->modx->getOption("seaccelerator.element_type_separation", null, "folder");
-		
-		$categories = array_reverse($filePathArray);
-		if ($separateElementTypeBy == "folder") {
-			$elementDirectory = str_replace("/", "", $elementDirectory);
-			if ($categories[0] == $elementDirectory) {
-				array_shift($categories);
-			}
-		}
-		
-		return $categories;
-	}
-	
-	
-	/**
-	 * @param $id
-	 * @param array $parents
-	 * @param array $categoryList
-	 */
-	private function _getParents($id, array $parents, array $categoryList) {
-		
-		$parents[] = $categoryList[$id]['name'];
-		$parent = $categoryList[$id]['parent'];
-		if ($parent != 0) {
-			$this->_getParents($parent, $parents, $categoryList);
-		} else {
-			$this->map = $parents;
-		}
-	}
-	
-	
+
+
+  /**
+   * @param $categoryId
+   * @return int|string
+   */
+  public function parseCategoryToPath($categoryId) {
+
+    if ($categoryId == 0) return;
+
+    $categories = $this->modx->getCollection('modCategory');
+    $list = [];
+    foreach ($categories as $category) {
+      $list[$category->id] = array (
+        'parent' => $category->parent,
+        'name' => $category->category
+      );
+    }
+    $this->_getParents($categoryId, array(), $list);
+    $parentsMap = join('/', array_reverse($this->map)) . "/";
+
+    return $parentsMap;
+  }
+
+
+  /**
+   * @param $filePathArray
+   * @param $elementDirectory
+   * @return array
+   */
+  public function prepareCategories($filePathArray, $elementDirectory) {
+
+    array_shift($filePathArray);
+    $separateElementTypeBy = $this->modx->getOption("seaccelerator.element_type_separation", null, "folder");
+
+    $categories = array_reverse($filePathArray);
+    if ($separateElementTypeBy == "folder") {
+      $elementDirectory = str_replace("/", "", $elementDirectory);
+      if ($categories[0] == $elementDirectory) {
+        array_shift($categories);
+      }
+    }
+
+    return $categories;
+  }
+
+
+  /**
+   * @param $id
+   * @param array $parents
+   * @param array $categoryList
+   */
+  private function _getParents($id, array $parents, array $categoryList) {
+
+    $parents[] = $categoryList[$id]['name'];
+    $parent = $categoryList[$id]['parent'];
+    if ($parent != 0) {
+      $this->_getParents($parent, $parents, $categoryList);
+    } else {
+      $this->map = $parents;
+    }
+  }
+
+
 	/**
 	 * @param array $files
 	 * @return bool
 	 */
 	public function createMultipleElements(array $files = array()) {
-		
+
 		if(!$files) {
 			$files = $this->getNewFiles();
 		}
-		
+
 		$result = false;
 		foreach($files as $file) {
-			
-			// TODO: Create method
-			$filePathArray = $this->getFilePathAsArray($file['file']);
-			$elementModClass = $this->getElementClass($filePathArray);
-			$elementDirectory = $this->getElementDirectory($filePathArray);
-			$categories = $this->prepareCategories($filePathArray, $elementDirectory);
-			
+
+      // TODO: Create method
+      $filePathArray = $this->getFilePathAsArray($file['file']);
+      $elementModClass = $this->getElementClass($filePathArray);
+      $elementDirectory = $this->getElementDirectory($filePathArray);
+      $categories = $this->prepareCategories($filePathArray, $elementDirectory);
+
 			$elementData = $this->makeElementDataArray($categories, $file["filename"], $file["path"], $elementModClass, $file["mediasource"]);
 			$elementObj  = $this->modx->newObject($elementModClass);
-			if (is_object($elementObj)) {
-				$result = $this->setAsStaticElement($elementObj, $elementData, false);
-			}
+      if (is_object($elementObj)) {
+        $result = $this->setAsStaticElement($elementObj, $elementData, false);
+      }
 		}
-		
+
 		return $result;
 	}
-	
-	
+
+
 	/**
 	 * @param $fileName
 	 * @param $filePath
 	 * @return bool
 	 */
 	public function createSingleElement($fileName, $filePath) {
-		
-		// TODO: Create method
+
+    // TODO: Create method
 		$file = str_replace( $this->getElementsDirectory(), '', $filePath ) .$fileName;
 		$filePathArray = $this->getFilePathAsArray($file);
-		$elementModClass = $this->getElementClass($filePathArray);
-		$elementDirectory = $this->getElementDirectory($filePathArray);
-		$categories = $this->prepareCategories($filePathArray, $elementDirectory);
-		
-		$isStatic = $this->_isElementStatic($file, $elementModClass);
-		$isNewFile = false;
-		$result = false;
-		
-		if($isStatic == false) {
+    $elementModClass = $this->getElementClass($filePathArray);
+    $elementDirectory = $this->getElementDirectory($filePathArray);
+    $categories = $this->prepareCategories($filePathArray, $elementDirectory);
+
+    $isStatic = $this->_isElementStatic($file, $elementModClass);
+    $isNewFile = false;
+    $result = false;
+
+    if($isStatic == false) {
 			$mediaSourceId = $this->modx->getOption("seaccelerator.mediasource", null, true);
 			$elementData 	 = $this->makeElementDataArray($categories, $fileName, $filePath, $elementModClass, $mediaSourceId);
 			$elementObj    = $this->modx->newObject($elementModClass);
-			if (is_object($elementObj)) {
-				$result = $this->setAsStaticElement($elementObj, $elementData, $isNewFile);
-			}
+      if (is_object($elementObj)) {
+        $result = $this->setAsStaticElement($elementObj, $elementData, $isNewFile);
+      }
 		}
-		
+
 		return $result;
 	}
-	
-	
-	/**
-	 * @param $filePath
-	 * @return mixed
-	 */
-	public function removeElementDirectory($filePath) {
-		
-		$category = str_replace("", "", $filePath);
-		
-		return $category;
-	}
-	
-	
+
+
+  /**
+   * @param $filePath
+   * @return mixed
+   */
+  public function removeElementDirectory($filePath) {
+
+    $category = str_replace("", "", $filePath);
+
+    return $category;
+  }
+
+
 	/**
 	 * @param $staticFile
 	 * @param $mediaSource
 	 * @return bool
 	 */
 	public function deleteFile($staticFile, $mediaSource = 1) {
-		
+
 		$file = $this->makeStaticElementFilePath('', $staticFile, $mediaSource, true);
-		
+
 		if($file) {
 			unlink($file);
 			return true;
@@ -774,26 +773,26 @@ class Seaccelerator {
 			return false;
 		}
 	}
-	
-	
+
+
 	/**
 	 * @param $id
 	 * @param $elementModClass
 	 * @return bool
 	 */
 	public function deleteElement($id, $elementModClass) {
-		
+
 		$element = $this->modx->getObject($elementModClass, $id);
 		if($element) {
 			$result = $element->remove();
 		} else {
 			$result = false;
 		}
-		
+
 		return $result;
 	}
-	
-	
+
+
 	/**
 	 * @param $id
 	 * @param $staticFile
@@ -802,80 +801,80 @@ class Seaccelerator {
 	 * @return bool
 	 */
 	public function deleteElementAndFile($id, $staticFile, $mediaSource, $elementModClass) {
-		
+
 		$result = $this->deleteElement($id, $elementModClass);
 		if ($result) {
 			$result = $this->deleteFile($staticFile, $mediaSource);
 		}
-		
+
 		return $result;
 	}
-	
-	
-	/**
-	 * @param $elementData
-	 * @return bool|mixed
-	 */
-	public function exportElementAsStatic($elementData) {
-		
-		$parameter = array("id" => $elementData['id']);
+
+
+  /**
+   * @param $elementData
+   * @return bool|mixed
+   */
+  public function exportElementAsStatic($elementData) {
+
+    $parameter = array("id" => $elementData['id']);
 		/** @var modElement $elementObj */
-		$elementObj = $this->modx->getObject($elementData['modClass'], $parameter);
-		if (is_object($elementObj)) {
+    $elementObj = $this->modx->getObject($elementData['modClass'], $parameter);
+    if (is_object($elementObj)) {
 			$result = $elementObj->setFileContent( $elementObj->get("content") );
-			
-		} else {
-			$result = false;
-		}
-		
-		return $result;
-	}
-	
-	
+
+    } else {
+      $result = false;
+    }
+
+    return $result;
+  }
+
+
 	/**
 	 * @param $elementType
 	 * @return array
 	 */
 	public function exportElementsAsStatic($elementType) {
-		
+
 		$modObjectType = $this->modElementClasses[$elementType][0];
 		$parameter = array("static" => 0);
 		$elements = $this->modx->getCollection($modObjectType, $parameter);
-		
+
 		$result = [];
 		$elementsFolder = $this->getElementsLocationFilesystemPath();
 		$suffix = $this->getFileSuffix($elementType);
-		
+
 		foreach($elements as $elementObj) {
 			$name = $elementObj->get("name");
 			$elementData["name"] = $elementObj->get("name");
 			$elementData["content"] = $elementObj->get("content");
-			
+
 			if (!empty($elementData["name"]) && !empty($elementData["content"])) {
 				$elementData["file"] = $elementsFolder.$elementType."/".$name.$suffix;
 				$result = $this->setAsStaticElement($elementObj, $elementData, true);
 			}
 		}
-		
+
 		return $result;
 	}
-	
-	
-	/**
-	 * @param $elementData
-	 * @return mixed
-	 */
-	public function updateChunkFromStaticFile($elementData) {
-		
-		$file = $this->makeStaticElementFilePath($elementData["file"], $elementData["path"], $elementData["source"], true);
-		
-		$elementData["content"] = $this->getFileContent($file);
-		$elementObj = $this->modx->getObject($elementData["modClass"], $elementData["id"]);
-		
-		return $this->saveElementObject($elementObj, $elementData, true);
-	}
-	
-	
+
+
+  /**
+   * @param $elementData
+   * @return mixed
+   */
+  public function updateChunkFromStaticFile($elementData) {
+
+    $file = $this->makeStaticElementFilePath($elementData["file"], $elementData["path"], $elementData["source"], true);
+
+    $elementData["content"] = $this->getFileContent($file);
+    $elementObj = $this->modx->getObject($elementData["modClass"], $elementData["id"]);
+
+    return $this->saveElementObject($elementObj, $elementData, true);
+  }
+
+
 	/**
 	 * @param $elementObj
 	 * @param $elementData
@@ -883,20 +882,20 @@ class Seaccelerator {
 	 * @return bool|mixed
 	 */
 	public function setAsStaticElement($elementObj, $elementData, $isNewFile) {
-		
+
 		$result = false;
 		if ($isNewFile) {
 			$result = $this->saveElementToFilesystem($elementData);
 		}
-		
+
 		if ($result !== false || !$isNewFile) {
 			$result = $this->saveElementObject($elementObj, $elementData, true);
 		}
-		
+
 		return $result;
 	}
-	
-	
+
+
 	/**
 	 * @param $elementObj
 	 * @param $elementData
@@ -904,46 +903,46 @@ class Seaccelerator {
 	 * @return bool|mixed
 	 */
 	public function unsetAsStaticElement($elementObj, $elementData, $elementType) {
-		
+
 		$result = $this->saveElementObject($elementObj, $elementType, false);
 		$file = $this->makeStaticElementFilePath($elementData["file"], $elementData["mediaSourceId"], $elementData["path"], true);
-		
+
 		if ($result) {
 			$result = $this->deleteFile($file);
 		}
-		
+
 		return $result;
 	}
-	
-	
+
+
 	/**
 	 * @param $elementData
 	 * @return bool
 	 */
 	public function saveElementToFilesystem($elementData) {
-		
-		$result = file_put_contents($elementData["file"], $elementData["content"]);
+
+    $result = file_put_contents($elementData["file"], $elementData["content"]);
 		if ($result === false) {
-			$parts = explode('/', $elementData["file"]);
-			$file = array_pop($parts);
-			if ($parts[0] == "") {
-				array_shift($part);
-			};
-			$dir = '';
-			foreach($parts as $part) {
-				if (!is_dir($dir .= "/$part")) mkdir($dir, 0644);
-			}
-			$result = file_put_contents("$dir/$file", $elementData["content"]);
-			if ($result !== false){
-				$result = true;
-			}
+      $parts = explode('/', $elementData["file"]);
+      $file = array_pop($parts);
+      if ($parts[0] == "") {
+        array_shift($part);
+      };
+      $dir = '';
+      foreach($parts as $part) {
+        if (!is_dir($dir .= "/$part")) mkdir($dir, 0644);
+      }
+      $result = file_put_contents("$dir/$file", $elementData["content"]);
+      if ($result !== false){
+        $result = true;
+      }
 		} else {
-			$result = true;
+      $result = true;
 		}
-		return $result;
+    return $result;
 	}
-	
-	
+
+
 	/**
 	 * @param $elementObj
 	 * @param $elementData
@@ -951,48 +950,48 @@ class Seaccelerator {
 	 * @return mixed
 	 */
 	public function saveElementObject($elementObj, $elementData, $static) {
-		
-		$fieldName = $this->getElementFieldName($elementData["type"]);
-		
+
+    $fieldName = $this->getElementFieldName($elementData["type"]);
+
 		$elementObj->set($fieldName, $elementData["name"]);
 		$elementObj->set("source", $elementData["source"]);
 		$elementObj->set("static_file", $elementData["static_file"]);
 		$elementObj->set("category", $elementData["categoryId"]);
 		$elementObj->set("content", $elementData["content"]);
 		$elementObj->set("static", $static);
-		
+
 		$result = $elementObj->save();
-		
+
 		return $result;
 	}
-	
-	
-	/**
-	 * @param $elementObj
-	 * @param $elementRecord
-	 * @return mixed
-	 */
-	public function updateElement($elementObj, $elementRecord) {
-		
-		$elementData['name'] = $elementRecord['name'];
-		$elementData['source'] = $elementRecord['source'];
-		$elementData['static_file'] = $elementRecord['static_file'];
-		$elementData['category'] = $elementRecord['category'];
-		$elementData['content'] = $elementRecord['content'];
-		//$elementData['description'] = $elementRecord['description'];
-		
-		$result = $this->saveElementObject($elementObj, $elementData, true);
-		
-		return $result;
-	}
-	
-	
+
+
+  /**
+   * @param $elementObj
+   * @param $elementRecord
+   * @return mixed
+   */
+  public function updateElement($elementObj, $elementRecord) {
+
+    $elementData['name'] = $elementRecord['name'];
+    $elementData['source'] = $elementRecord['source'];
+    $elementData['static_file'] = $elementRecord['static_file'];
+    $elementData['category'] = $elementRecord['category'];
+    $elementData['content'] = $elementRecord['content'];
+    //$elementData['description'] = $elementRecord['description'];
+
+    $result = $this->saveElementObject($elementObj, $elementData, true);
+
+    return $result;
+  }
+
+
 	/**
 	 * @param $type
 	 * @return mixed
 	 */
 	public function getFileSuffix($type) {
-		
+
 		if (strpos($type, "mod") !== false) {
 			$fileSuffixes = array(
 				"modChunk" => ".html",
@@ -1000,7 +999,7 @@ class Seaccelerator {
 				"modSnippet" => ".php",
 				"modPlugin" => ".php"
 			);
-			
+
 		} else {
 			$fileSuffixes = array(
 				"chunks" => ".html",
@@ -1009,21 +1008,21 @@ class Seaccelerator {
 				"plugins" => ".php"
 			);
 		}
-		
+
 		return $fileSuffixes[$type];
 	}
-	
-	
+
+
 	/**
 	 * @param $file
 	 * @return bool|string
 	 */
 	private function getFileContent($file) {
-		
+
 		return file_get_contents($file, true);
 	}
-	
-	
+
+
 	/**
 	 * @param $file
 	 * @return string
@@ -1031,8 +1030,8 @@ class Seaccelerator {
 	public function getFileContentAsSHA1($file) {
 		return sha1_file($file);
 	}
-	
-	
+
+
 	/**
 	 * @param $file
 	 * @return string
@@ -1044,11 +1043,11 @@ class Seaccelerator {
 		} else {
 			$content = "";
 		}
-		
+
 		return $content;
 	}
-	
-	
+
+
 	/**
 	 * @param $category
 	 * @param $fileName
@@ -1058,74 +1057,74 @@ class Seaccelerator {
 	 * @return mixed
 	 */
 	public function makeElementDataArray($category, $fileName, $filePath, $elementModClass, $mediaSourceId) {
-		
+
 		$elementData["categoryId"]  = $this->parseCategory($category);
 		$elementData["name"] 			  = $this->makeElementName($fileName);
-		$elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $mediaSourceId, false);
-		$elementData["file"] 			  = $this->makeStaticElementFilePath($fileName, $filePath, $mediaSourceId, true);
-		$elementData["content"] 	  = $this->getFileContent($elementData['file']);
-		$elementData["type"]  		  = $elementModClass;
-		$elementData["source"]      = $mediaSourceId;
-		
-		return $elementData;
+    $elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $mediaSourceId, false);
+    $elementData["file"] 			  = $this->makeStaticElementFilePath($fileName, $filePath, $mediaSourceId, true);
+    $elementData["content"] 	  = $this->getFileContent($elementData['file']);
+    $elementData["type"]  		  = $elementModClass;
+    $elementData["source"]      = $mediaSourceId;
+
+    return $elementData;
 	}
-	
-	
+
+
 	/**
 	 * @param $results
 	 * @return mixed
 	 */
 	public function prepareElementGridData($results, $classKey) {
-		
+
 		foreach ($results as $result) {
 			$name = $result->get('name');
 			$filename = $this->makeFilename($name, $classKey);
-			
+
 			$elementData['name']  			= $name;
 			$elementData['filename']		= $filename;
 			$elementData['content']  		= $result->get('content');
 			$elementData['static_file'] = $result->get('static_file');
 			$elementData['static']  		= $result->get('static');
 			$elementData['source'] 			= $result->get('source');
-			//$elementData['category'] 		= $result->get('category');
-			$elementData['classKey'] 		= $classKey;
-			
-			$result->set('category_name', $this->getCategoryName($result->get('category')));
+      //$elementData['category'] 		= $result->get('category');
+      $elementData['classKey'] 		= $classKey;
+
+      $result->set('category_name', $this->getCategoryName($result->get('category')));
 			$result->set('status', $this->getElementStatusIcon($elementData));
 			$result->set('actions', $this->getElementActionIcons($elementData));
 		}
-		
+
 		return $results;
 	}
-	
-	
+
+
 	/**
 	 * @param $name
 	 * @param $classKey
 	 * @return string
 	 */
 	public function makeFilename($name, $classKey) {
-		
+
 		$suffix = $this->getFileSuffix($classKey);
-		
+
 		return $name.$suffix;
 	}
-	
-	
+
+
 	/**
 	 * @param $elementData
 	 * @return array
 	 */
 	public function checkElementStatus($elementData) {
-		
+
 		$status['path'] 	 = $elementData['path'];
 		$status['static']  = $elementData['static'];
 		$status['deleted'] = false;
 		$status['changed'] = false;
-		
+
 		// Element has an path and is static
 		if ($elementData['static'] == true && $elementData['static_file'] != "") {
-			
+
 			$path = str_replace($elementData['filename'], "", $elementData['static_file']);
 			$file = $this->makeStaticElementFilePath($elementData['filename'], $path, $elementData['source'], true);
 
@@ -1136,77 +1135,77 @@ class Seaccelerator {
 			if ($elementContentFilesystem == "") {
 				$status['deleted'] = true;
 			}
-			
+
 			// Has content changed?
 			if ($elementContentDatabase != $elementContentFilesystem) {
 				$status['changed'] = true;
 			}
 		}
-		
+
 		$elementStatus = $this->setElementStatusAndAction($status);
-		
+
 		return $elementStatus;
 	}
-	
-	
+
+
 	/**
 	 * @param $status
 	 * @return array
 	 */
 	public function setElementStatusAndAction($status) {
-		
+
 		$statusAndActions = [];
-		
+
 		if ($status['deleted'] == true) {
 			$statusAndActions['status'] = "deleted";
 			$statusAndActions['action'] = array("editElement", "syncToFile", "syncFromFileDisabled", "deleteElement", "deleteBothDisabled");
-			
+
 		} else if ($status['static'] == false) {
 			$statusAndActions['status'] = "static";
 			$statusAndActions['action'] = array("editElement", "syncToFile", "syncFromFileDisabled", "deleteElement", "deleteBothDisabled");
-			
+
 		} else if ($status['deleted'] == false && $status['changed'] == true) {
 			$statusAndActions['status'] = "changed";
 			$statusAndActions['action'] = array("editElement", "syncToFile", "syncFromFile", "deleteElement", "deleteBoth");
-			
+
 		} else if ($status['deleted'] == false && $status['changed'] == false) {
 			$statusAndActions['status'] = "unchanged";
 			$statusAndActions['action'] = array("editElement", "syncToFileDisabled", "syncFromFileDisabled", "deleteElement", "deleteBoth");
 		}
-		
+
 		return $statusAndActions;
 	}
-	
-	
+
+
 	/**
 	 * @param $elementData
 	 * @return mixed
 	 */
 	public function getElementStatusIcon($elementData) {
-		
+
 		$statusAndAction = $this->checkElementStatus($elementData);
-		
+
 		$statusIconRepository = array(
 			'changed' => '{"className":"exclamation-circle sm-orange","text":"'. $this->modx->lexicon('seaccelerator.elements.element_status.changed') .'"}',
 			'unchanged' => '{"className":"check-circle sm-green","text":"'. $this->modx->lexicon('seaccelerator.elements.element_status.unchanged') .'"}',
 			'deleted' => '{"className":"warning sm-red","text":"'. $this->modx->lexicon('seaccelerator.elements.element_status.deleted') .'"}',
 			'static' => '{"className":"info-circle sm-orange","text":"'. $this->modx->lexicon('seaccelerator.elements.element_status.not_static') .'"}'
 		);
-		
+
 		return json_decode($statusIconRepository[$statusAndAction['status']]);
 	}
-	
-	
+
+
 	/**
 	 * @param $elementData
 	 * @return array
 	 */
 	public function getElementActionIcons($elementData) {
-		
+
 		$statusAndActions = $this->checkElementStatus($elementData);
 		$actions = $statusAndActions['action'];
 		$actionIcons = [];
-		
+
 		$actionIconsRepository = array(
 			'editElement' =>   				 '{"className":"edit js_actionLink js_editElement","text":"'. $this->modx->lexicon('seaccelerator.elements.actions.quickupdate') .'"}',
 			'syncToFile' =>  	 				 '{"className":"arrow-circle-o-down js_actionLink js_syncToFile","text":"'. $this->modx->lexicon('seaccelerator.elements.actions.sync.tofile') .'"}',
@@ -1217,7 +1216,7 @@ class Seaccelerator {
 			'deleteBoth' => 	 				 '{"className":"trash js_actionLink js_deleteFileElement","text":"'. $this->modx->lexicon('seaccelerator.elements.actions.delete_file_element') .'"}',
 			'deleteBothDisabeld' => 	 '{"className":"trash disabled","text":"'. $this->modx->lexicon('seaccelerator.elements.actions.delete_file_element') .'"}',
 		);
-		
+
 		foreach ($actionIconsRepository as $actionIcon => $actionIconContent) {
 			foreach ($actions as $action) {
 				if ($action == $actionIcon) {
@@ -1225,26 +1224,26 @@ class Seaccelerator {
 				}
 			}
 		}
-		
+
 		return $actionIcons;
 	}
-	
-	
-	/**
-	 * @param $results
-	 * @return mixed
-	 */
-	public function addCategoryName($results) {
-		
-		foreach ($results as $result) {
-			$categoryId = $result->get('category');
-			$this->modx->log(xPDO::LOG_LEVEL_DEBUG, $categoryId);
-			//$category = $this->getCategoryName($categoryId);
-			//$result->set('category', $category);
-		}
-		
-		return $results;
-	}
-	
-	
+
+
+  /**
+   * @param $results
+   * @return mixed
+   */
+  public function addCategoryName($results) {
+
+    foreach ($results as $result) {
+      $categoryId = $result->get('category');
+      $this->modx->log(xPDO::LOG_LEVEL_DEBUG, $categoryId);
+      //$category = $this->getCategoryName($categoryId);
+      //$result->set('category', $category);
+    }
+
+    return $results;
+  }
+
+
 }

--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -819,33 +819,10 @@ class Seaccelerator {
 	public function exportElementAsStatic($elementData) {
 		
 		$parameter = array("id" => $elementData['id']);
+		/** @var modElement $elementObj */
 		$elementObj = $this->modx->getObject($elementData['modClass'], $parameter);
 		if (is_object($elementObj)) {
-			
-			//$elementArr = $elementObj->toArray();
-			//$this->modx->log(xPDO::LOG_LEVEL_DEBUG, $elementArr);
-			//$elementData['path']
-			
-			// TODO: One method that handles the files. Input: filename, category, source. Method will return the needed paths.
-			$elementCategory = $this->parseCategoryToPath($elementData["category_id"]);
-			$elementDirectory = $this->getElementDirectory($elementData['modClass']);
-			
-			$fileSuffix = $this->getFileSuffix($elementData['modClass']);
-			$fileName = $elementData['name'].$fileSuffix;
-			$filePath = $elementDirectory . "/" . $elementCategory;
-			
-			// TODO: Logic for default media source
-			$elementData["source"] = $this->defaultMediaSource;
-			$elementData["content"] = $elementObj->get("content");
-			
-			//$elementData["name"] = $element->get("name");
-			//$elementData["content"] = $element->get("content");
-			// TODO: This method is deprecated
-			$elementData["folder"] = $this->getElementsLocationFilesystemPath();
-			$elementData["file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], true);
-			$elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], false);;
-			$elementIsNewFile = true;
-			$result = $this->setAsStaticElement($elementObj, $elementData, $elementIsNewFile);
+			$result = $elementObj->setFileContent( $elementObj->get("content") );
 			
 		} else {
 			$result = false;

--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -818,10 +818,33 @@ class Seaccelerator {
   public function exportElementAsStatic($elementData) {
 
     $parameter = array("id" => $elementData['id']);
-		/** @var modElement $elementObj */
     $elementObj = $this->modx->getObject($elementData['modClass'], $parameter);
     if (is_object($elementObj)) {
-			$result = $elementObj->setFileContent( $elementObj->get("content") );
+
+      //$elementArr = $elementObj->toArray();
+      //$this->modx->log(xPDO::LOG_LEVEL_DEBUG, $elementArr);
+      //$elementData['path']
+
+      // TODO: One method that handles the files. Input: filename, category, source. Method will return the needed paths.
+      $elementCategory = $this->parseCategoryToPath($elementData["category_id"]);
+      $elementDirectory = $this->getElementDirectory($elementData['modClass']);
+
+      $fileSuffix = $this->getFileSuffix($elementData['modClass']);
+      $fileName = $elementData['name'].$fileSuffix;
+      $filePath = $elementDirectory . "/" . $elementCategory;
+
+      // TODO: Logic for default media source
+      $elementData["source"] = $this->defaultMediaSource;
+      $elementData["content"] = $elementObj->get("content");
+
+      //$elementData["name"] = $element->get("name");
+      //$elementData["content"] = $element->get("content");
+      // TODO: This method is deprecated
+      $elementData["folder"] = $this->getElementsLocationFilesystemPath();
+      $elementData["file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], true);
+      $elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], false);;
+      $elementIsNewFile = true;
+      $result = $this->setAsStaticElement($elementObj, $elementData, $elementIsNewFile);
 
     } else {
       $result = false;

--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -352,6 +352,10 @@ class Seaccelerator {
 			$mediaSourceId = $mediaSource;
 		}
 		
+		if ( 0 !== strpos( $filePath, '/' . $this->getElementsDirectory() ) &&
+		     0 !== strpos( $filePath, $this->getElementsDirectory() ) ) {
+			$filePath = '/' . $this->getElementsDirectory() . $filePath;
+		}
 		$elementsPath = $this->getBaseFilesystemPath( $mediaSourceId );
 		
 		if($makeFullPath !== true) {


### PR DESCRIPTION
Variety of changes to fix multiple issues, al in some ways related to the file path handling.
From design perspective this PR changes the displayed paths in the Manager to include the configured Elements Directory. This is better, because this way the path listed in the Manager matches the path shown under Static File property of the Static elements (+ also matches the `static_file` value in the db). It is also better for more consistent path handling for different commands coming from the Manager.