### PR TITLE
Improve the way file of existing static element is updated

### DIFF
--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -784,6 +784,19 @@ class Seaccelerator {
     /** @var modElement $elementObj */
     $elementObj = $this->modx->getObject($elementData['modClass'], $parameter);
     if (is_object($elementObj)) {
+	  if ( ! $elementObj->isStatic() ) {
+	      $elementCategory = $this->parseCategoryToPath($elementData["category_id"]);
+	      $elementDirectory = $this->getElementDirectory($elementData['modClass']);
+	  
+	      $fileSuffix = $this->getFileSuffix($elementData['modClass']);
+	      $fileName = $elementData['name'].$fileSuffix;
+	      $filePath = $elementDirectory . "/" . $elementCategory;
+	      $elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $this->defaultMediaSource, false);
+	      $elementObj->set('static', true );
+	      $elementObj->set('source', $this->defaultMediaSource );
+	      $elementObj->set('static_file', $elementData["static_file"] ); // this must be the last one
+	      $elementObj->save();
+	  }
 	  $result = $elementObj->setFileContent( $elementObj->get("content") );
 
     } else {

--- a/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
+++ b/core/components/seaccelerator/model/seaccelerator/seaccelerator.class.php
@@ -781,33 +781,10 @@ class Seaccelerator {
   public function exportElementAsStatic($elementData) {
 
     $parameter = array("id" => $elementData['id']);
+    /** @var modElement $elementObj */
     $elementObj = $this->modx->getObject($elementData['modClass'], $parameter);
     if (is_object($elementObj)) {
-
-      //$elementArr = $elementObj->toArray();
-      //$this->modx->log(xPDO::LOG_LEVEL_DEBUG, $elementArr);
-      //$elementData['path']
-
-      // TODO: One method that handles the files. Input: filename, category, source. Method will return the needed paths.
-      $elementCategory = $this->parseCategoryToPath($elementData["category_id"]);
-      $elementDirectory = $this->getElementDirectory($elementData['modClass']);
-
-      $fileSuffix = $this->getFileSuffix($elementData['modClass']);
-      $fileName = $elementData['name'].$fileSuffix;
-      $filePath = $elementDirectory . "/" . $elementCategory;
-
-      // TODO: Logic for default media source
-      $elementData["source"] = $this->defaultMediaSource;
-      $elementData["content"] = $elementObj->get("content");
-
-      //$elementData["name"] = $element->get("name");
-      //$elementData["content"] = $element->get("content");
-      // TODO: This method is deprecated
-      $elementData["folder"] = $this->getElementsLocationFilesystemPath();
-      $elementData["file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], true);
-      $elementData["static_file"] = $this->makeStaticElementFilePath($fileName, $filePath, $elementData['source'], false);;
-      $elementIsNewFile = true;
-      $result = $this->setAsStaticElement($elementObj, $elementData, $elementIsNewFile);
+	  $result = $elementObj->setFileContent( $elementObj->get("content") );
 
     } else {
       $result = false;


### PR DESCRIPTION
Instead of using elaborate custom procedure simple one line php can be used based on built in ModX function to update the file related to a static element.
This at the same time fixes an issue, when the previous custom procedure did not add back php opening tag to the php files which are removed from the db by ModX.
By calling the built in methods, this is handled by the system.