### PR TITLE
Fix Making non-static Template Static

### DIFF
--- a/assets/components/seaccelerator/js/mgr/widgets/elements.grid.js
+++ b/assets/components/seaccelerator/js/mgr/widgets/elements.grid.js
@@ -432,7 +432,7 @@ Ext.extend(Seaccelerator.grid.Elements, MODx.grid.Grid, {
 			,params: {
 				action: 'mgr/elements/sync'
 				,id: this.menu.record.id
-        ,name: this.menu.record.data.name
+                ,name: this.menu.record.data.name || this.menu.record.data.templatename // Templates use templatename instead of name
 				,staticfile: this.menu.record.data.static_file
         ,source: this.menu.record.data.source
         ,category: this.menu.record.data.category


### PR DESCRIPTION
Fix: templates are listed in a way that the name is in the templatename attribute, not the name. To prevent creating static files with empty filenames (like '.html'), we need to use this.menu.record.data.templatename instead of this.menu.record.data.name (when this.menu.record.data.name is not set)